### PR TITLE
110 - CoccaEpp verify peer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
-        "africc/php-epp2": "^1.0",
+        "africc/php-epp2": "^2.0",
         "centralnic-reseller/php-sdk": "^8.0",
         "fakerphp/faker": "^1.0",
         "guzzlehttp/guzzle": "^6.3|^7.0",

--- a/src/CentralNicReseller/Helper/CentralNicResellerApi.php
+++ b/src/CentralNicReseller/Helper/CentralNicResellerApi.php
@@ -28,9 +28,7 @@ class CentralNicResellerApi
 
     public function __destruct()
     {
-        if (isset($this->client)) {
-            $this->client->logout();
-        }
+        $this->client->logout();
     }
 
     /**

--- a/src/CoccaEpp/Client.php
+++ b/src/CoccaEpp/Client.php
@@ -160,10 +160,10 @@ class Client extends EPPClient
     /**
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
-    public function connect()
+    public function connect($newPassword = false)
     {
         try {
-            return parent::connect();
+            return parent::connect($newPassword);
         } catch (Exception $e) {
             if (Str::contains($e->getMessage(), ['Timeout', 'timeout', 'timed out'])) {
                 $this->error(

--- a/src/CoccaEpp/Client.php
+++ b/src/CoccaEpp/Client.php
@@ -144,8 +144,10 @@ class Client extends EPPClient
     protected function login($newPassword = false)
     {
         try {
-            parent::login();
+            $response = parent::login($newPassword);
             $this->loggedIn = true;
+
+            return $response;
         } catch (Exception $e) {
             $this->error(
                 sprintf(

--- a/src/CoccaEpp/Client.php
+++ b/src/CoccaEpp/Client.php
@@ -167,7 +167,7 @@ class Client extends EPPClient
         try {
             return parent::connect($newPassword);
         } catch (Exception $e) {
-            if (Str::contains($e->getMessage(), ['Timeout', 'timeout', 'timed out'])) {
+            if (Str::contains($e->getMessage(), ['Timeout', 'timeout', 'timed out', 'problem initializing socket'])) {
                 $this->error(
                     sprintf('Registry Connection Error: %s', $e->getMessage()),
                     $e

--- a/src/CoccaEpp/Data/Configuration.php
+++ b/src/CoccaEpp/Data/Configuration.php
@@ -14,7 +14,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read integer|null $port
  * @property-read string|null $certificate
  * @property-read string|null $supported_tlds
- * @property-read boolean|null verify_peer_name
+ * @property-read bool|null $verify_peer_name
  */
 class Configuration extends DataSet
 {

--- a/src/CoccaEpp/Data/Configuration.php
+++ b/src/CoccaEpp/Data/Configuration.php
@@ -8,14 +8,13 @@ use Upmind\ProvisionBase\Provider\DataSet\DataSet;
 use Upmind\ProvisionBase\Provider\DataSet\Rules;
 
 /**
- * Nira configuration.
- *
  * @property-read string $epp_username
  * @property-read string $epp_password
  * @property-read string $hostname
  * @property-read integer|null $port
  * @property-read string|null $certificate
  * @property-read string|null $supported_tlds
+ * @property-read boolean|null verify_peer_name
  */
 class Configuration extends DataSet
 {
@@ -28,6 +27,7 @@ class Configuration extends DataSet
             'port' => ['nullable', 'integer', 'min:1'],
             'certificate' => ['nullable', 'certificate_pem'],
             'supported_tlds' => ['nullable', 'string'],
+            'verify_peer_name' => ['nullable', 'boolean'],
         ]);
     }
 }

--- a/src/CoccaEpp/Provider.php
+++ b/src/CoccaEpp/Provider.php
@@ -78,7 +78,11 @@ class Provider extends DomainNames implements ProviderInterface
                 : __DIR__ . '/default_cert.pem',
             $this->getLogger(),
             [
-                'verify_peer_name' => (bool) $this->configuration->verify_peer_name,
+                // Pass verify_peer_name config as boolean.
+                // If null, default to true, otherwise cast to boolean as it might be a string or int.
+                'verify_peer_name' => $this->configuration->verify_peer_name === null
+                    ? true
+                    : (bool) $this->configuration->verify_peer_name,
             ]
         );
     }

--- a/src/CoccaEpp/Provider.php
+++ b/src/CoccaEpp/Provider.php
@@ -79,10 +79,8 @@ class Provider extends DomainNames implements ProviderInterface
             $this->getLogger(),
             [
                 // Pass verify_peer_name config as boolean.
-                // If null, default to true, otherwise cast to boolean as it might be a string or int.
-                'verify_peer_name' => $this->configuration->verify_peer_name === null
-                    ? true
-                    : (bool) $this->configuration->verify_peer_name,
+                // Cast to boolean, so nullable defaults to false and the rest are handled correctly even if string/int.
+                'verify_peer_name' => (bool) $this->configuration->verify_peer_name
             ]
         );
     }

--- a/src/CoccaEpp/Provider.php
+++ b/src/CoccaEpp/Provider.php
@@ -76,7 +76,10 @@ class Provider extends DomainNames implements ProviderInterface
             $this->configuration->certificate
                 ? $this->getCertificatePath($this->configuration->certificate)
                 : __DIR__ . '/default_cert.pem',
-            $this->getLogger()
+            $this->getLogger(),
+            [
+                'verify_peer_name' => (bool) $this->configuration->verify_peer_name,
+            ]
         );
     }
 

--- a/src/SynergyWholesale/Helper/SynergyWholesaleApi.php
+++ b/src/SynergyWholesale/Helper/SynergyWholesaleApi.php
@@ -135,10 +135,13 @@ class SynergyWholesaleApi
         $response = $this->makeRequest($command, $params)['domainList'][0];
         $this->parseResponseData($command, $response);
 
+        /** @var \Illuminate\Support\Collection $statusesCollection */
+        $statusesCollection = collect([$response['status'], $response['domain_status']]);
+
         return [
             'id' => $response['domainRoid'],
             'domain' => (string)$response['domainName'],
-            'statuses' => collect([$response['status'], $response['domain_status']])
+            'statuses' => $statusesCollection
                 ->map(fn ($status) => strtoupper($status))
                 ->unique()
                 ->values()

--- a/src/SynergyWholesale/Provider.php
+++ b/src/SynergyWholesale/Provider.php
@@ -319,17 +319,21 @@ class Provider extends DomainNames implements ProviderInterface
 
         $hostname = $this->configuration->custom_api_hostname ?: 'api.synergywholesale.com';
 
-        try {
-            // apparently the only way to set the actual timeout for SoapClient
-            $defaultTimeout = ini_set("default_socket_timeout", "5");
+        // apparently the only way to set the actual timeout for SoapClient
+        // init_set sets the value and returns the old value.
+        $defaultTimeout = ini_set("default_socket_timeout", "5");
 
+        try {
             $client = new SoapClient(sprintf('https://%s/?wsdl', $hostname));
 
             return $this->api = new SynergyWholesaleApi($client, $this->configuration, $this->getLogger());
         } catch (Throwable $e) {
             $this->handleException($e);
         } finally {
-            ini_set("default_socket_timeout", $defaultTimeout);
+            if ($defaultTimeout !== false) {
+                // restore the default timeout
+                ini_set("default_socket_timeout", $defaultTimeout);
+            }
         }
     }
 


### PR DESCRIPTION
Closes #110 

- Add new configuration for `verify_peer_name`
- Default to true if null, otherwise boolean
- Update `africc/php-epp2` to `v2.0.0` so it allows passing `verify_peer_name` param
- Update Cocca client to follow interface of updated `africc/php-epp2` library