### PR TITLE
Simplify SynergyWholesale contact updates

### DIFF
--- a/src/SynergyWholesale/Helper/SynergyWholesaleApi.php
+++ b/src/SynergyWholesale/Helper/SynergyWholesaleApi.php
@@ -398,22 +398,6 @@ class SynergyWholesaleApi
             "nexusCategory" => "",
         ];
 
-        $info = $this->getDomainInfo($domainName);
-
-
-        $contacts = [
-            self::CONTACT_TYPE_ADMIN => $info['admin'],
-            self::CONTACT_TYPE_TECH => $info['tech'],
-            self::CONTACT_TYPE_BILLING => $info['billing'],
-        ];
-
-        foreach ($contacts as $type => $contact) {
-            if ($contact) {
-                $contactParams = $this->setContactData($contact, $type);
-                $params = array_merge($params, $contactParams);
-            }
-        }
-
         $params = array_merge($params, $this->setContactParams($registrantParams, self::CONTACT_TYPE_REGISTRANT));
 
         $this->makeRequest($command, $params);


### PR DESCRIPTION
Remove the admin, billing & tech contacts from updateRegistrantContact - This will result in synergy applying the registrant contact submitted to all contacts on the domain.

This resolves errors where other contacts might have invalid data resulting in rejections, and where clients are otherwise unable to update their admin/tech/billing contact due to upmind limitations.