### PR TITLE
Fix broken getInfo / verifyownership

### DIFF
--- a/src/UGRegistry/Provider.php
+++ b/src/UGRegistry/Provider.php
@@ -655,7 +655,7 @@ class Provider extends DomainNames implements ProviderInterface
         ];
 
         try {
-            $this->_updateDomain($domain, $contacts, []);
+            $this->_updateDomain($domain, $contacts, $ns);
         } catch (ProvisionFunctionError $e) {
             if (Str::contains($e->getMessage(), 'domain is locked')) {
                 return;


### PR DESCRIPTION
verifyownership submits empty array for nameservers, which results in error - this fixes it by passing through current ns