### PR TITLE
CentralNic Reseller - Get correct expiration date

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-          tools: composer, phpstan
+          tools: composer, phpstan:1
 
       - name: "Get composer cache directory"
         id: composer-cache

--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -216,8 +216,8 @@ class EppHelper
         return [
             'id' => $response->getDomainId(),
             'domain' => $response->getDomainName(),
-            'statuses' => $response->getDomainStatuses() ?? [],
-            'locked' => boolval(array_intersect($this->lockedStatuses, $response->getDomainStatuses() ?? [])),
+            'statuses' => $this->statusesToStrings($response->getDomainStatuses() ?? []),
+            'locked' => boolval(array_intersect($this->lockedStatuses, $this->statusesToStrings($response->getDomainStatuses() ?? []))),
             'registrant' => $registrantId ? $this->getContactInfo($registrantId) : null,
             'billing' => $billingId ? $this->getContactInfo($billingId) : null,
             'tech' => $techId ? $this->getContactInfo($techId) : null,
@@ -227,6 +227,22 @@ class EppHelper
             'updated_at' => Utils::formatDate($response->getDomainUpdateDate() ?: $response->getDomainCreateDate()),
             'expires_at' => Utils::formatDate($this->getDomainExpirationDateFromResponse($response)),
         ];
+    }
+
+    /**
+     * @param string[]|\Metaregistrar\EPP\eppStatus[] $statuses
+     *
+     * @return string[]
+     */
+    protected function statusesToStrings(array $statuses): array
+    {
+        return array_map(function ($status) {
+            if ($status instanceof \Metaregistrar\EPP\eppStatus) {
+                return $status->getStatusname();
+            }
+
+            return (string)$status;
+        }, $statuses);
     }
 
     /**

--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Helper;
 
 use Carbon\Carbon;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Illuminate\Support\Str;
+use Metaregistrar\EPP\eppResponse;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Helper;
 use Metaregistrar\EPP\rrpproxyEppRenewalmodeRequest;
 use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
@@ -187,7 +191,7 @@ class EppHelper
         return [
             'domain' => $response->getDomainName(),
             'created_at' => Utils::formatDate($response->getDomainCreateDate()),
-            'expires_at' => Utils::formatDate($response->getDomainExpirationDate())
+            'expires_at' => Utils::formatDate($this->getDomainExpirationDateFromResponse($response))
         ];
     }
 
@@ -219,7 +223,7 @@ class EppHelper
             'ns' => $this->parseNameServers($response->getDomainNameservers() ?? []),
             'created_at' => Utils::formatDate($response->getDomainCreateDate()),
             'updated_at' => Utils::formatDate($response->getDomainUpdateDate() ?: $response->getDomainCreateDate()),
-            'expires_at' => Utils::formatDate($response->getDomainExpirationDate()),
+            'expires_at' => Utils::formatDate($this->getDomainExpirationDateFromResponse($response)),
         ];
     }
 
@@ -258,7 +262,7 @@ class EppHelper
         /** @var \Metaregistrar\EPP\eppInfoDomainResponse $response */
         $response = $this->connection->request($info);
 
-        $expiresAt = Utils::formatDate($response->getDomainExpirationDate(), 'Y-m-d');
+        $expiresAt = Utils::formatDate($this->getDomainExpirationDateFromResponse($response), 'Y-m-d');
 
         $renewRequest = new eppRenewRequest($domainData, $expiresAt);
 
@@ -594,5 +598,48 @@ class EppHelper
         }
 
         return $uncreatedHosts;
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getDomainExpirationDateFromResponse(eppResponse $response): string
+    {
+        $expirationDate = $response->queryPath('/epp:epp/epp:response/epp:resData/domain:creData/domain:exDate');
+
+        $paidUntilDate = $response->queryPath(
+            '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:punDate'
+        );
+
+        $renewalDate = $response->queryPath(
+            '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:renDate'
+        );
+
+        // If all potential expiration dates are null, throw error
+        if ($expirationDate === null && $paidUntilDate === null && $renewalDate === null) {
+            throw new ProvisionFunctionError('No expiration date found in EPP response.');
+        }
+
+        // If only the expiration date is available, return it
+        if ($paidUntilDate === null && $renewalDate === null) {
+            return $expirationDate;
+        }
+
+        // Now we handle cases where either paidUntilDate or renewalDate is available
+        if ($paidUntilDate !== null && $renewalDate === null) {
+            return $paidUntilDate;
+        }
+
+        if ($paidUntilDate === null && $renewalDate !== null) {
+            return $renewalDate;
+        }
+
+        // Lastly, if both paidUntilDate and renewalDate are available,
+        // compare the two dates,
+        // and return the earliest one.
+        $paidUntil = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $paidUntilDate);
+        $renewal = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $renewalDate);
+
+        return $paidUntil <= $renewal ? $paidUntilDate : $renewalDate;
     }
 }

--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -160,6 +160,7 @@ class EppHelper
      * @param Nameserver[]  $nameServers
      *
      * @throws \Metaregistrar\EPP\eppException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function register(
         string $domainName,
@@ -197,6 +198,7 @@ class EppHelper
 
     /**
      * @throws \Metaregistrar\EPP\eppException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function getDomainInfo(string $domainName): array
     {
@@ -251,6 +253,7 @@ class EppHelper
 
     /**
      * @throws \Metaregistrar\EPP\eppException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function renew(string $domainName, int $period): void
     {

--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -608,7 +608,8 @@ class EppHelper
      */
     private function getDomainExpirationDateFromResponse(eppResponse $response): string
     {
-        $expirationDate = $response->queryPath('/epp:epp/epp:response/epp:resData/domain:creData/domain:exDate');
+        $expirationDate = $response->queryPath('/epp:epp/epp:response/epp:resData/domain:infData/domain:exDate')
+            ?? $response->queryPath('/epp:epp/epp:response/epp:resData/domain:creData/domain:exDate');
 
         $paidUntilDate = $response->queryPath(
             '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:punDate'

--- a/src/CentralNicReseller/Provider.php
+++ b/src/CentralNicReseller/Provider.php
@@ -269,6 +269,7 @@ class Provider extends DomainNames implements ProviderInterface
 
     /**
      * @throws \Metaregistrar\EPP\eppException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function _getInfo(string $domain, $msg = 'Domain data obtained'): DomainResult
     {

--- a/src/CentralNicReseller/Provider.php
+++ b/src/CentralNicReseller/Provider.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use ErrorException;
 use Illuminate\Support\Arr;
 use Metaregistrar\EPP\eppException;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionBase\Provider\DataSet\ResultData;
@@ -160,6 +161,14 @@ class Provider extends DomainNames implements ProviderInterface
             );
 
             return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (ProvisionFunctionError $e) {
+            // Handle specific ProvisionFunctionError if needed
+            $this->errorResult(
+                sprintf('Domain %s registration  error: %s', $domainName, $e->getMessage()),
+                $e->getData(),
+                array_merge($e->getDebug(), $params->toArray()),
+                $e
+            );
         } catch (eppException $e) {
             $this->_eppExceptionHandler($e);
         }
@@ -220,6 +229,14 @@ class Provider extends DomainNames implements ProviderInterface
             $this->epp()->renew($domainName, $period);
 
             return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (ProvisionFunctionError $e) {
+            // Handle specific ProvisionFunctionError if needed
+            $this->errorResult(
+                sprintf('Domain %s renewal  error: %s', $domainName, $e->getMessage()),
+                $e->getData(),
+                array_merge($e->getDebug(), $params->toArray()),
+                $e
+            );
         } catch (eppException $e) {
             $this->_eppExceptionHandler($e);
         }
@@ -237,6 +254,14 @@ class Provider extends DomainNames implements ProviderInterface
 
         try {
             return $this->_getInfo($domainName);
+        } catch (ProvisionFunctionError $e) {
+            // Handle specific ProvisionFunctionError if needed
+            $this->errorResult(
+                sprintf('Domain %s get info  error: %s', $domainName, $e->getMessage()),
+                $e->getData(),
+                array_merge($e->getDebug(), $params->toArray()),
+                $e
+            );
         } catch (eppException $e) {
             $this->_eppExceptionHandler($e);
         }


### PR DESCRIPTION
Closes #121 

It seems that CentralNic doesn't return a definite expiration date within the standard epp response.
Instead, they add the Paid Until, & Renewal dates in their `metadata` (aka `extension` attribute of xml response) in some functions.

As such, best approach is to use a uniform call to get the appropriate expiration date depending what's present in the `eppResponse`