### PR TITLE
Prevent php to maintain SOAP connection open

### DIFF
--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -617,7 +617,10 @@ class Provider extends DomainNames implements ProviderInterface
                 $this->configuration->username,
                 $this->configuration->password,
                 $this->configuration->sandbox ? ClientFactory::ENV_TEST : ClientFactory::ENV_LIVE,
-                $this->getLogger()
+                $this->getLogger(),
+                [
+                    'keep_alive' => false
+                ]
             );
         } catch (Throwable $e) {
             $this->errorResult('Failed to connect to API', ['exception' => $e->getMessage()], [], $e);

--- a/src/SynergyWholesale/Provider.php
+++ b/src/SynergyWholesale/Provider.php
@@ -324,7 +324,9 @@ class Provider extends DomainNames implements ProviderInterface
         $defaultTimeout = ini_set("default_socket_timeout", "5");
 
         try {
-            $client = new SoapClient(sprintf('https://%s/?wsdl', $hostname));
+            $client = new SoapClient(sprintf('https://%s/?wsdl', $hostname), [
+                'keep_alive' => false,
+            ]);
 
             return $this->api = new SynergyWholesaleApi($client, $this->configuration, $this->getLogger());
         } catch (Throwable $e) {


### PR DESCRIPTION
Closes #123 

Due to a PHP Bug described in the issue, SOAP connections are not automatically closed on object descruction.
Add flag to prevent connection to remain open