### PR TITLE
133 - Hexonet Migration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+# Workflow name
+name: Unit Tests
+
+# Triggers
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+# Jobs/Pipelines
+jobs:
+  phpunit:
+    name: 'PHP Unit'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.1, 8.2, 8.3 ]
+    steps:
+      - name: "Checkout Code"
+        uses: actions/checkout@v4
+
+      - name: "Setup PHP with tools"
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+          tools: composer, phpunit
+
+      - name: "Get composer cache directory"
+        id: composer-cache
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
+
+      - name: "Cache dependencies"
+        uses: actions/cache@v4
+        with:
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-php-${{ matrix.php}}-composer-"
+
+      - name: "Install Composer dependencies"
+        run: composer install --no-ansi --no-interaction --no-progress --no-scripts --prefer-dist
+
+      - name: "Run PHPUnit Tests"
+        run: phpunit

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "ext-simplexml": "*",
         "ext-xml": "*",
         "africc/php-epp2": "^2.0",
-        "centralnic-reseller/php-sdk": "^8.0",
+        "centralnic-reseller/php-sdk": "^11",
         "fakerphp/faker": "^1.0",
         "guzzlehttp/guzzle": "^6.3|^7.0",
         "metaregistrar/php-epp-client": "^1.0.12",

--- a/src/CentralNicReseller/Helper/CentralNicResellerApi.php
+++ b/src/CentralNicReseller/Helper/CentralNicResellerApi.php
@@ -21,9 +21,19 @@ class CentralNicResellerApi
     /**
      * @throws \Exception
      */
-    public function __construct(Configuration $configuration, LoggerInterface $logger)
+    public function __construct(Configuration $configuration, LoggerInterface $logger, string $registrar = 'cnr')
     {
-        $this->client = $this->establishConnection($configuration, $logger);
+        switch (mb_strtolower($registrar)) {
+            case 'moniker':
+                $registrar = 'MONIKER'; // Use MONIKER for Moniker registrar
+                break;
+            case 'centralnic-reseller':
+            case 'cnr':
+            default:
+                $registrar = 'CNR'; // CNR is the default registrar
+        }
+
+        $this->client = $this->establishConnection($configuration, $logger, $registrar);
     }
 
     public function __destruct()
@@ -36,11 +46,14 @@ class CentralNicResellerApi
      *
      * @throws \Exception
      */
-    protected function establishConnection(Configuration $configuration, LoggerInterface $logger): CentralNicResellerClient
-    {
+    protected function establishConnection(
+        Configuration $configuration,
+        LoggerInterface $logger,
+        string $registrar = 'CNR' // Default to CNR if not specified
+    ): CentralNicResellerClient {
         /** @var \CNIC\CNR\SessionClient $client */
         $client = CF::getClient([
-            "registrar" => "CNR"
+            'registrar' => $registrar
         ]);
 
         $client->setCredentials($configuration->username, $configuration->password);

--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -374,7 +374,7 @@ class EppHelper
         /** @var \Metaregistrar\EPP\eppInfoDomainResponse $response */
         $response = $this->connection->request($info);
 
-        return $response->getDomainStatuses();
+        return $this->statusesToStrings($response->getDomainStatuses() ?? []);
     }
 
     public function getLockedStatuses(): array

--- a/src/Hexonet/Data/Configuration.php
+++ b/src/Hexonet/Data/Configuration.php
@@ -21,7 +21,7 @@ class Configuration extends DataSet
     {
         return new Rules([
             'username' => ['required', 'string', 'min:3'],
-            'password' => ['required', 'string', 'min:6', 'max:16'],
+            'password' => ['required', 'string', 'min:6'],
             'migrated' => ['nullable', 'string', 'in:not-migrated,centralnic-reseller,moniker'],
             'sandbox' => ['nullable', 'boolean'],
         ]);

--- a/src/Hexonet/Data/Configuration.php
+++ b/src/Hexonet/Data/Configuration.php
@@ -12,6 +12,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  *
  * @property-read string $username
  * @property-read string $password
+ * @property-read string|null $migrated
  * @property-read bool|null $sandbox
  */
 class Configuration extends DataSet
@@ -21,6 +22,7 @@ class Configuration extends DataSet
         return new Rules([
             'username' => ['required', 'string', 'min:3'],
             'password' => ['required', 'string', 'min:6', 'max:16'],
+            'migrated' => ['nullable', 'string', 'in:not-migrated,centralnic-reseller,moniker'],
             'sandbox' => ['nullable', 'boolean'],
         ]);
     }

--- a/src/Hexonet/Provider.php
+++ b/src/Hexonet/Provider.php
@@ -948,7 +948,7 @@ class Provider extends DomainNames implements ProviderInterface
     }
 
     /**
-     * @return \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category
+     * @return \Upmind\ProvisionBase\Provider\Contract\ProviderInterface
      *
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
@@ -1001,7 +1001,6 @@ class Provider extends DomainNames implements ProviderInterface
 
         $this->migratedProvider->setLogger($this->getLogger());
 
-        /** @var \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category */
         return $this->migratedProvider;
     }
 }

--- a/src/Hexonet/Provider.php
+++ b/src/Hexonet/Provider.php
@@ -999,6 +999,8 @@ class Provider extends DomainNames implements ProviderInterface
                 );
         }
 
+        $this->migratedProvider->setLogger($this->getLogger());
+
         /** @var \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category */
         return $this->migratedProvider;
     }

--- a/src/Hexonet/Provider.php
+++ b/src/Hexonet/Provider.php
@@ -948,7 +948,7 @@ class Provider extends DomainNames implements ProviderInterface
     }
 
     /**
-     * @return \Upmind\ProvisionBase\Provider\Contract\ProviderInterface
+     * @return \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category
      *
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
@@ -1001,6 +1001,7 @@ class Provider extends DomainNames implements ProviderInterface
 
         $this->migratedProvider->setLogger($this->getLogger());
 
+        /** @var \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category */
         return $this->migratedProvider;
     }
 }

--- a/src/Hexonet/Provider.php
+++ b/src/Hexonet/Provider.php
@@ -8,6 +8,8 @@ use GuzzleHttp\Client;
 use Illuminate\Support\Arr;
 use Metaregistrar\EPP\eppContactHandle;
 use Metaregistrar\EPP\eppException;
+use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Data\Configuration as CentralNicResellerConfiguration;
+use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Provider as CentralNicResellerProvider;
 use Upmind\ProvisionProviders\DomainNames\Hexonet\Helper\EppHelper;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
@@ -36,6 +38,8 @@ use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
 use Upmind\ProvisionProviders\DomainNames\Hexonet\Data\Configuration;
 use Upmind\ProvisionProviders\DomainNames\Hexonet\EppExtension\EppConnection;
 use Upmind\ProvisionProviders\DomainNames\Hexonet\Helper\HexonetApi;
+use Upmind\ProvisionProviders\DomainNames\Moniker\Data\Configuration as MonikerConfiguration;
+use Upmind\ProvisionProviders\DomainNames\Moniker\Provider as MonikerProvider;
 
 /**
  * "Curiosity killed the cat..."
@@ -72,6 +76,9 @@ class Provider extends DomainNames implements ProviderInterface
      */
     protected $hexonetApi;
 
+    private bool $migrated;
+    private ?ProviderInterface $migratedProvider = null;
+
     // Name Servers for Hexonet
     private const NAMESERVERS = [
         [
@@ -100,8 +107,19 @@ class Provider extends DomainNames implements ProviderInterface
 
     public function __construct(Configuration $configuration)
     {
-        // dont connect straight away - wait until function call for any connection errors to surface
+        // don't connect straight away - wait until function call for any connection errors to surface
         $this->configuration = $configuration;
+
+        switch ($this->configuration->migrated) {
+            case 'centralnic-reseller':
+            case 'moniker':
+                $this->migrated = true;
+                break;
+            case 'not-migrated':
+            case null:
+            default:
+                $this->migrated = false; // Default to not migrated
+        }
     }
 
     /**
@@ -129,6 +147,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function domainAvailabilityCheck(DacParams $params): DacResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->domainAvailabilityCheck($params);
+        }
+
         $dac = new Dac($this->configuration, new Client([
             'handler' => $this->getGuzzleHandlerStack(!!$this->configuration->sandbox),
         ]));
@@ -141,6 +163,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function poll(PollParams $params): PollResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->poll($params);
+        }
+
         $this->errorResult('Operation not supported');
     }
 
@@ -155,6 +181,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function register(RegisterDomainParams $params): DomainResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->register($params);
+        }
+
         $domain = Utils::getDomain(Arr::get($params, 'sld'), Arr::get($params, 'tld'));
 
         // Establish connection to Hexonet API via EPP protocol
@@ -347,6 +377,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function transfer(TransferParams $params): DomainResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->transfer($params);
+        }
+
         // Get the domain name
         $domain = Utils::getDomain($params->sld, $params->tld);
         $eppCode = $params->epp_code;
@@ -408,6 +442,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function renew(RenewParams $params): DomainResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->renew($params);
+        }
+
         // Get the domain name
         $tld = Arr::get($params, 'tld');
 
@@ -443,6 +481,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function getInfo(DomainInfoParams $params): DomainResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->getInfo($params);
+        }
+
         // Get the domain name
         $domain = Utils::getDomain(Arr::get($params, 'sld'), Arr::get($params, 'tld'));
 
@@ -500,6 +542,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function updateNameservers(UpdateNameserversParams $params): NameserversResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->updateNameservers($params);
+        }
+
         // Get Domain Name and NameServers
         $domain = Utils::getDomain(Arr::get($params, 'sld'), Arr::get($params, 'tld'));
 
@@ -535,6 +581,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function getEppCode(EppParams $params): EppCodeResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->getEppCode($params);
+        }
+
         // Get the domain name
         $domain = Utils::getDomain(Arr::get($params, 'sld'), Arr::get($params, 'tld'));
 
@@ -560,6 +610,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function updateIpsTag(IpsTagParams $params): ResultData
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->updateIpsTag($params);
+        }
+
         $this->errorResult('Operation not supported', $params);
     }
 
@@ -573,6 +627,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->updateRegistrantContact($params);
+        }
+
         // Don't use this approach for now - for registrant name/org changes it throws an error requiring a trade
         // return to it when we next have an example of a domain with 531 Authorization Error for registrant updates:
         // $api = HexonetHelper::establishConnection($this->configuration->toArray());
@@ -631,6 +689,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function setLock(LockParams $params): DomainResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->setLock($params);
+        }
+
         // Get the domain name
         $domain = Utils::getDomain(Arr::get($params, 'sld'), Arr::get($params, 'tld'));
         $lock = Arr::get($params, 'lock');
@@ -691,6 +753,10 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function setAutoRenew(AutoRenewParams $params): DomainResult
     {
+        if ($this->migrated) {
+            return $this->getMigratedProvider()->setAutoRenew($params);
+        }
+
         // Get the domain name
         $domain = Utils::getDomain(Arr::get($params, 'sld'), Arr::get($params, 'tld'));
         $autoRenew = !!$params->auto_renew;
@@ -879,5 +945,61 @@ class Provider extends DomainNames implements ProviderInterface
     protected function api(): HexonetApi
     {
         return $this->hexonetApi ??= new HexonetApi($this->configuration, $this->getLogger());
+    }
+
+    /**
+     * @return \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getMigratedProvider(): ProviderInterface
+    {
+        // Not migrated, don't call this method
+        if (!$this->migrated) {
+            $this->errorResult(
+                'Migrated Provider is not set in the configuration',
+                [],
+                [
+                    'migrated' => $this->configuration->migrated,
+                ]
+            );
+        }
+
+        // If we have already instantiated the migrated provider instance, return it
+        if ($this->migratedProvider !== null) {
+            return $this->migratedProvider;
+        }
+
+        switch ($this->configuration->migrated) {
+            case 'centralnic-reseller':
+                $configuration = new CentralNicResellerConfiguration([
+                    'username' => $this->configuration->username,
+                    'password' => $this->configuration->password,
+                    'sandbox' => $this->configuration->sandbox
+                ]);
+
+                $this->migratedProvider = new CentralNicResellerProvider($configuration);
+                break;
+            case 'moniker':
+                $configuration = new MonikerConfiguration([
+                    'username' => $this->configuration->username,
+                    'password' => $this->configuration->password,
+                    'sandbox' => $this->configuration->sandbox
+                ]);
+
+                $this->migratedProvider = new MonikerProvider($configuration);
+                break;
+            default:
+                $this->errorResult(
+                    'Migrated Provider is not set in the configuration',
+                    [],
+                    [
+                        'migrated' => $this->configuration->migrated,
+                    ]
+                );
+        }
+
+        /** @var \Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category */
+        return $this->migratedProvider;
     }
 }

--- a/src/Hexonet/Provider.php
+++ b/src/Hexonet/Provider.php
@@ -77,6 +77,10 @@ class Provider extends DomainNames implements ProviderInterface
     protected $hexonetApi;
 
     private bool $migrated;
+
+    /**
+     * @var (\Upmind\ProvisionBase\Provider\Contract\ProviderInterface&\Upmind\ProvisionProviders\DomainNames\Category)|null
+     */
     private ?ProviderInterface $migratedProvider = null;
 
     // Name Servers for Hexonet

--- a/src/Moniker/Data/Configuration.php
+++ b/src/Moniker/Data/Configuration.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Moniker\Data;
+
+use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Data\Configuration as CentralNicResellerConfiguration;
+
+/**
+ * Moniker configuration.
+ *
+ * @property-read string $username
+ * @property-read string $password
+ * @property-read bool|null $sandbox
+ */
+class Configuration extends CentralNicResellerConfiguration
+{
+}

--- a/src/Moniker/Provider.php
+++ b/src/Moniker/Provider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Moniker;
+
+use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Helper\CentralNicResellerApi;
+use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Provider as CentralNicResellerProvider;
+use Upmind\ProvisionProviders\DomainNames\Moniker\Data\Configuration;
+
+/**
+ * Moniker provider.
+ *
+ * Moniker is using the same API as CentralNic Reseller, so it extends it, but passing 'MONIKER' as the registrar.
+ */
+class Provider extends CentralNicResellerProvider
+{
+    public function __construct(Configuration $configuration)
+    {
+        parent::__construct($configuration);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function api(): CentralNicResellerApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        $this->api = new CentralNicResellerApi($this->configuration, $this->getLogger(), 'MONIKER');
+
+        return $this->api;
+    }
+}

--- a/src/Moniker/Provider.php
+++ b/src/Moniker/Provider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionProviders\DomainNames\Moniker;
 
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Helper\CentralNicResellerApi;
 use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Provider as CentralNicResellerProvider;
 use Upmind\ProvisionProviders\DomainNames\Moniker\Data\Configuration;
@@ -18,6 +19,17 @@ class Provider extends CentralNicResellerProvider
     public function __construct(Configuration $configuration)
     {
         parent::__construct($configuration);
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Moniker')
+            ->setDescription(
+                'Moniker, Built For Domain Investors. '
+                . 'Buy, sell, manage, and monetize domain names.'
+            )
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/moniker-logo_2x.png');
     }
 
     /**


### PR DESCRIPTION
Closes #133 

Hexonet is being deprecated, and users are moved to either `CentralNic Reseller` or `Moniker`
For easier transition, the following changes were made

- New Hexonet config param `migrated`, with available values `not-migrated`, `centralnic-reseller`, `moniker`. Defaults to `not-migrated`
- Add new `Moniker` Provider. This is using Centralnic Reseller API under the hood.
- If migrated, instantiate the relevant provider with the credentials found in the hexonet configuration, and perform API calls from them
- Remove max character limitation on hexonet configuration `password` field

Also added init test Github Action
