### PR TITLE
137 - OpenSRS - Improvide domain availability check error handling

### DIFF
--- a/src/OpenSRS/Helper/OpenSrsApi.php
+++ b/src/OpenSRS/Helper/OpenSrsApi.php
@@ -185,7 +185,7 @@ class OpenSrsApi
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
-    public function makeRequestAsync(array $params): PromiseInterface
+    public function makeRequestAsync(array $params, array $requestOptions = []): PromiseInterface
     {
         // Request Template
         $xmlDataBlock = self::array2xml($params);
@@ -201,7 +201,7 @@ class OpenSrsApi
             self::XML_INDENT . '</body>' . self::CRLF .
             '</OPS_envelope>';
 
-        return $this->client->requestAsync('POST', $this->getApiEndpoint(), [
+        return $this->client->requestAsync('POST', $this->getApiEndpoint(), array_merge([
             'body' => $xml,
             'headers' => [
                 'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/OpenSRS',
@@ -210,7 +210,7 @@ class OpenSrsApi
                 'X-Signature' => md5(md5($xml . $this->configuration->key) . $this->configuration->key),
                 'Content-Length' => strlen($xml)
             ],
-        ])->then(function (Response $response) {
+        ], $requestOptions))->then(function (Response $response) {
             $result = $response->getBody()->getContents();
 
             if (empty($result)) {

--- a/src/OpenSRS/Helper/OpenSrsApi.php
+++ b/src/OpenSRS/Helper/OpenSrsApi.php
@@ -351,7 +351,8 @@ class OpenSrsApi
         }
 
         if ((int)$data['is_success'] === 0 && !in_array($data['response_code'], [200, 212])) {
-            $errorMessage = 'Registrar API Error: ' . $data['response_text'];
+            $providerMessage = $data['response_text'] ?? 'Empty response from provider';
+            $errorMessage = 'Registrar API Error: ' . $providerMessage;
 
             if ($data['response_code'] == 400) {
                 $errorMessage = 'Registrar API Authentication Error';

--- a/src/OpenSRS/Helper/OpenSrsApi.php
+++ b/src/OpenSRS/Helper/OpenSrsApi.php
@@ -201,7 +201,7 @@ class OpenSrsApi
             self::XML_INDENT . '</body>' . self::CRLF .
             '</OPS_envelope>';
 
-        return $this->client->requestAsync('POST', $this->getApiEndpoint(), array_merge([
+        return $this->client->requestAsync('POST', $this->getApiEndpoint(), array_merge($requestOptions, [
             'body' => $xml,
             'headers' => [
                 'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/OpenSRS',
@@ -210,7 +210,7 @@ class OpenSrsApi
                 'X-Signature' => md5(md5($xml . $this->configuration->key) . $this->configuration->key),
                 'Content-Length' => strlen($xml)
             ],
-        ], $requestOptions))->then(function (Response $response) {
+        ]))->then(function (Response $response) {
             $result = $response->getBody()->getContents();
 
             if (empty($result)) {

--- a/src/OpenSRS/Provider.php
+++ b/src/OpenSRS/Provider.php
@@ -130,48 +130,13 @@ class Provider extends DomainNames implements ProviderInterface
                         ->setDescription($description);
                 })
                 ->otherwise(function (ProvisionFunctionError $e) use ($params, $tld): DacDomain {
-                    if (Str::contains($e->getMessage(), ['TLD not serviced', 'Invalid domain syntax'])) {
-                        return DacDomain::create()
-                            ->setDomain(Utils::getDomain($params->sld, $tld))
-                            ->setTld($tld)
-                            ->setCanRegister(false)
-                            ->setCanTransfer(false)
-                            ->setIsPremium(false)
-                            ->setDescription($e->getMessage());
-                    }
-
-                    $errorData = $e->getData();
-
-                    if (isset($errorData['status'])
-                        && (int) $errorData['is_success'] === 0
-                        && (!isset($errorData['response_code']) || $errorData['response_code'] === '')
-                        && (!isset($errorData['response_text']) || $errorData['response_text'] === '')
-                        && (!isset($errorData['attributes']['status']) || $errorData['attributes']['status'] === '')
-                    ) {
-                        // In some cases, OpenSRS returns an error without a proper response code or text,
-                        // usually when the TLD is not supported or the domain syntax is invalid on the lookup call.
-                        // Log the error and return a DacDomain with the error message
-                        $this->getLogger()->error(
-                            'Domain availability check failed',
-                            [
-                                'sld' => $params->sld,
-                                'tld' => $tld,
-                                'error' => $e->getMessage(),
-                                'data' => $errorData,
-                                'debug' => $e->getDebug()
-                            ]
-                        );
-
-                        return DacDomain::create()
-                            ->setDomain(Utils::getDomain($params->sld, $tld))
-                            ->setTld($tld)
-                            ->setCanRegister(false)
-                            ->setCanTransfer(false)
-                            ->setIsPremium(false)
-                            ->setDescription('Invalid/Unsupported TLD or domain syntax');
-                    }
-
-                    throw $e;
+                    return DacDomain::create()
+                        ->setDomain(Utils::getDomain($params->sld, $tld))
+                        ->setTld($tld)
+                        ->setCanRegister(false)
+                        ->setCanTransfer(false)
+                        ->setIsPremium(false)
+                        ->setDescription($e->getMessage());
                 });
         }, $params->tlds);
 

--- a/src/OpenSRS/Provider.php
+++ b/src/OpenSRS/Provider.php
@@ -138,6 +138,37 @@ class Provider extends DomainNames implements ProviderInterface
                             ->setDescription($e->getMessage());
                     }
 
+                    $errorData = $e->getData();
+
+                    if (isset($errorData['status'])
+                        && (int) $errorData['is_success'] === 0
+                        && (!isset($errorData['response_code']) || $errorData['response_code'] === '')
+                        && (!isset($errorData['response_text']) || $errorData['response_text'] === '')
+                        && (!isset($errorData['attributes']['status']) || $errorData['attributes']['status'] === '')
+                    ) {
+                        // In some cases, OpenSRS returns an error without a proper response code or text,
+                        // usually when the TLD is not supported or the domain syntax is invalid on the lookup call.
+                        // Log the error and return a DacDomain with the error message
+                        $this->getLogger()->error(
+                            'Domain availability check failed',
+                            [
+                                'sld' => $params->sld,
+                                'tld' => $tld,
+                                'error' => $e->getMessage(),
+                                'data' => $errorData,
+                                'debug' => $e->getDebug()
+                            ]
+                        );
+
+                        return DacDomain::create()
+                            ->setDomain(Utils::getDomain($params->sld, $tld))
+                            ->setTld($tld)
+                            ->setCanRegister(false)
+                            ->setCanTransfer(false)
+                            ->setIsPremium(false)
+                            ->setDescription('Invalid/Unsupported TLD or domain syntax');
+                    }
+
                     throw $e;
                 });
         }, $params->tlds);

--- a/src/OpenSRS/Provider.php
+++ b/src/OpenSRS/Provider.php
@@ -108,6 +108,8 @@ class Provider extends DomainNames implements ProviderInterface
                         'domain' => Utils::getDomain($params->sld, $tld),
                         'no_cache' => 0,
                     ],
+                ], [
+                    'timeout' => 10, // Set a reduced timeout for the request
                 ])
                 ->then(function (array $result) use ($params, $tld): DacDomain {
                     $register = $result['attributes']['status'] === 'available';


### PR DESCRIPTION
Closes #137 

- Improve error handling for `domain availability check` method, for potentially unsupported tlds that fail lookup query without message