### PR TITLE
v2.12 - Enom - DateTimeImmutable construct fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the package will be documented in this file.
 
+## [v2.12.47](https://github.com/upmind-automation/provision-provider-domain-names/releases/tag/v2.12.47) - 2025-07-25
+
+- Fix Enom provider DateTimeImmutable instantiation
+
 ## [v2.12.46](https://github.com/upmind-automation/provision-provider-domain-names/releases/tag/v2.12.46) - 2025-07-24
 
 - Fix Moniker provider binding in Laravel service

--- a/src/Enom/Helper/EnomApi.php
+++ b/src/Enom/Helper/EnomApi.php
@@ -404,7 +404,7 @@ class EnomApi
                 ]);
         }
 
-        $now = new DateTimeImmutable('now', 'UTC');
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
 
         // The API call is different if domain has expired, ie expiration date is in the past or not
         // But also check that status is also expired.


### PR DESCRIPTION
DateTimeImmutable requires DateTimeZone object, not string as second param.