### PR TITLE
Organisation field should now be optional

### DIFF
--- a/src/OpenSRS/Provider.php
+++ b/src/OpenSRS/Provider.php
@@ -208,7 +208,7 @@ class Provider extends DomainNames implements ProviderInterface
 
                 $contacts[$type] = array_filter([
                     'country' => Utils::normalizeCountryCode($contactParams->country_code),
-                    'org_name' => $contactParams->organisation ?: $contactParams->name,
+                    'org_name' => $contactParams->organisation,
                     'phone' => Utils::internationalPhoneToEpp($contactParams->phone),
                     'postal_code' => $contactParams->postcode,
                     'city' => $contactParams->city,
@@ -340,7 +340,7 @@ class Provider extends DomainNames implements ProviderInterface
             $contacts[$type] = [
                 'country' => Utils::normalizeCountryCode($contactParams->country_code),
                 'state' => Utils::stateNameToCode($contactParams->country_code, $contactParams->state),
-                'org_name' => $contactParams->organisation ?: $contactParams->name,
+                'org_name' => $contactParams->organisation,
                 'phone' => Utils::internationalPhoneToEpp($contactParams->phone),
                 'postal_code' => $contactParams->postcode,
                 'city' => $contactParams->city,


### PR DESCRIPTION
With recent ICANN changes, the org field should be optional and be allowed to be set to blank without overrides.

https://opensrs.com/blog/what-icanns-updated-registration-data-policy-rdp-means-for-opensrs-resellers/