### PR TITLE
150 - Realtime Register - Transfer lu domains without period

### DIFF
--- a/src/RealtimeRegister/Helper/RealtimeRegisterApi.php
+++ b/src/RealtimeRegister/Helper/RealtimeRegisterApi.php
@@ -616,6 +616,7 @@ class RealtimeRegisterApi
         return !in_array(Utils::getRootTld($domain), [
             'nl',
             'nu',
+            'lu'
         ]);
     }
 }


### PR DESCRIPTION
Closes #150 

- Add .lu domain to list of domains to exclude period when transferring