### PR TITLE
Add Ascio domain registrar provider

### DIFF
--- a/src/Ascio/Data/Configuration.php
+++ b/src/Ascio/Data/Configuration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Ascio\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Ascio configuration
+ *
+ * @property-read string $username Account
+ * @property-read string $password Password
+ * @property-read bool|null $sandbox Make API requests against the sandbox environment
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string', 'min:6'],
+            'password' => ['required', 'string', 'min:3'],
+            'sandbox' => ['nullable', 'boolean'],
+        ]);
+    }
+}

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -365,30 +365,30 @@ class AscioApi
 
         $params = [
             'Type' => 'Register',
-            'Domain' => (object) [
+            'Domain' => (object)[
                 'Name' => $domainName,
                 'NameServers' => $nameserverParams,
                 'RenewPeriod' => $period,
                 'Owner' => new SoapVar(
-                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_REGISTRANT]],
+                    (object)['Handle' => $contacts[self::CONTACT_TYPE_REGISTRANT]],
                     SOAP_ENC_OBJECT,
                     'Registrant',
                     'http://www.ascio.com/2013/02'
                 ),
                 'Admin' => new SoapVar(
-                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_ADMIN]],
+                    (object)['Handle' => $contacts[self::CONTACT_TYPE_ADMIN]],
                     SOAP_ENC_OBJECT,
                     'Contact',
                     'http://www.ascio.com/2013/02'
                 ),
                 'Tech' => new SoapVar(
-                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_TECH]],
+                    (object)['Handle' => $contacts[self::CONTACT_TYPE_TECH]],
                     SOAP_ENC_OBJECT,
                     'Contact',
                     'http://www.ascio.com/2013/02'
                 ),
                 'Billing' => new SoapVar(
-                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_BILLING]],
+                    (object)['Handle' => $contacts[self::CONTACT_TYPE_BILLING]],
                     SOAP_ENC_OBJECT,
                     'Contact',
                     'http://www.ascio.com/2013/02'
@@ -497,30 +497,30 @@ class AscioApi
 
         $params = [
             'Type' => 'Transfer',
-            'Domain' => (object) [
+            'Domain' => (object)[
                 'Name' => $domainName,
                 'NameServers' => $nameserverParams,
                 'AuthInfo' => $eppCode,
                 'Owner' => new SoapVar(
-                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_REGISTRANT]),
+                    (object)$this->setContactParams($contacts[self::CONTACT_TYPE_REGISTRANT]),
                     SOAP_ENC_OBJECT,
                     'Registrant',
                     'http://www.ascio.com/2013/02'
                 ),
                 'Admin' => new SoapVar(
-                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_ADMIN]),
+                    (object)$this->setContactParams($contacts[self::CONTACT_TYPE_ADMIN]),
                     SOAP_ENC_OBJECT,
                     'Contact',
                     'http://www.ascio.com/2013/02'
                 ),
                 'Tech' => new SoapVar(
-                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_TECH]),
+                    (object)$this->setContactParams($contacts[self::CONTACT_TYPE_TECH]),
                     SOAP_ENC_OBJECT,
                     'Contact',
                     'http://www.ascio.com/2013/02'
                 ),
                 'Billing' => new SoapVar(
-                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_BILLING]),
+                    (object)$this->setContactParams($contacts[self::CONTACT_TYPE_BILLING]),
                     SOAP_ENC_OBJECT,
                     'Contact',
                     'http://www.ascio.com/2013/02'
@@ -688,4 +688,35 @@ class AscioApi
 
         return $this->makeRequest($command, $params, 'CreateRegistrantResult')['Registrant']['Handle'] ?? null;
     }
+
+    /**
+     * @throws \SoapFault
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws NumberParseException
+     */
+    public function updateContact(
+        string        $domainName,
+        ContactParams $contactParams,
+        string        $contactType
+    ): ContactData
+    {
+        $command = 'createOrder';
+
+        if ($contactType == self::CONTACT_TYPE_REGISTRANT) {
+            return $this->updateRegistrantContact($domainName, $contactParams);
+        }
+
+        $params = [
+            'Type' => "ContactUpdate",
+            'Domain' => [
+                'Name' => $domainName,
+                $contactType => $this->setContactParams($contactParams)
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+
+        return $this->getDomainInfo($domainName)[$contactType];
+    }
+
 }

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -152,14 +152,17 @@ class AscioApi
 
         $info = $this->makeRequest($command, $params, 'GetDomainsResult');
 
-        try {
-            return $info['DomainInfos']['DomainInfo'];
-        } catch (\Exception $e) {
-            throw ProvisionFunctionError::create("Domain info not found for $domainName")
+
+        $domainInfo = $info['DomainInfos']['DomainInfo'] ?? null;
+
+        if ($domainInfo == null) {
+            throw ProvisionFunctionError::create("Domain not found: $domainName")
                 ->withData([
                     'response' => $info,
                 ]);
         }
+
+        return $domainInfo;
     }
 
 

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -1,0 +1,691 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Ascio\Helper;
+
+use Carbon\Carbon;
+use libphonenumber\NumberParseException;
+use SoapClient;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Psr\Log\LoggerInterface;
+use SoapHeader;
+use SoapVar;
+use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\DataSet\SystemInfo;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainNotification;
+use Upmind\ProvisionProviders\DomainNames\Data\GlueRecord;
+use Upmind\ProvisionProviders\DomainNames\Data\Nameserver;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\Ascio\Data\Configuration;
+
+/**
+ * Ascio Domains API client.
+ */
+class AscioApi
+{
+    /**
+     * Contact Types
+     */
+    public const CONTACT_TYPE_REGISTRANT = 'Owner';
+    public const CONTACT_TYPE_TECH = 'Tech';
+    public const CONTACT_TYPE_ADMIN = 'Admin';
+    public const CONTACT_TYPE_BILLING = 'Billing';
+
+    const MAX_CUSTOM_NAMESERVERS = 12;
+
+    protected SoapClient $client;
+
+    protected Configuration $configuration;
+
+    protected LoggerInterface $logger;
+
+    public function __construct(SoapClient $client, Configuration $configuration, LoggerInterface $logger)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @throws \SoapFault
+     */
+    public function makeRequest(string $command, ?array $params = null, string $responseField = null): ?array
+    {
+        if ($params) {
+            if ($command === 'createOrder') {
+                $requestParams = [
+                    'request' =>
+                        new SoapVar($params,
+                            SOAP_ENC_OBJECT,
+                            "DomainOrderRequest",
+                            "http://www.ascio.com/2013/02",
+                            "request",
+                            "http://www.ascio.com/2013/02/AscioService"),
+                ];
+            } else {
+                $requestParams = [
+                    'request' =>
+                        $params,
+                ];
+            }
+        }
+
+        $requestParams = $requestParams ?? [];
+
+        $this->logger->debug('Ascio API Request', [
+            'command' => $command,
+            'params' => $requestParams,
+            'pass' => $this->client->__getLastRequestHeaders(),
+        ]);
+
+        $response = $this->client->__soapCall($command, array($requestParams));
+        $responseData = json_decode(json_encode($response), true);
+
+        $this->logger->debug('Ascio API Response', [
+            'result' => $responseData,
+        ]);
+
+        $this->logger->debug('Ascio API header', [
+            'pass' => $this->client->__getLastRequest(),
+        ]);
+
+        return $this->parseResponseData($command, $response, $responseField)[$responseField];
+    }
+
+
+    /**
+     * @param array|\stdClass $result
+     */
+    private function parseResponseData(string $command, $result, string $responseField): array
+    {
+        $parsedResult = is_array($result) ? $result : json_decode(json_encode($result), true);
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($command, $parsedResult[$responseField])) {
+            throw ProvisionFunctionError::create(sprintf('Provider API Error: %s', $error))
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+
+    private function getResponseErrorMessage(string $command, array $responseData)
+    {
+        if ($responseData['ResultCode'] !== 200 && $responseData['ResultCode'] !== 201) {
+            $errorMessage = $responseData['ResultMessage'];
+        }
+
+        return $errorMessage ?? null;
+    }
+
+
+    /**
+     * @throws \SoapFault
+     */
+    public function getDomains(string $domainName)
+    {
+        $command = 'getDomains';
+        $params = [
+            'ObjectNames' => [$domainName],
+            "PageInfo" => [
+                "PageIndex" => 1,
+                "PageSize" => 1
+            ],
+            "OrderSort" => "CreatedDesc",
+        ];
+
+        $info = $this->makeRequest($command, $params, 'GetDomainsResult');
+
+        try {
+            return $info['DomainInfos']['DomainInfo'];
+        } catch (\Exception $e) {
+            throw ProvisionFunctionError::create("Domain info not found for $domainName")
+                ->withData([
+                    'response' => $info,
+                ]);
+        }
+    }
+
+
+    public function getDomainInfo(string $domainName): array
+    {
+        $response = $this->getDomains($domainName);
+
+        return $this->parseDomainData($response);
+    }
+
+
+    public function parseDomainData(array $response): array
+    {
+        return [
+            'id' => $response['DomainHandle'],
+            'domain' => (string)$response['DomainName'],
+            'statuses' => [$response['Status']],
+            'locked' => $response['TransferLock'] == 'Lock' && $response['UpdateLock'] == 'Lock',
+            'registrant' => isset($response['Owner'])
+                ? $this->parseContact($response['Owner'])
+                : null,
+            'billing' => isset($response['Billing'])
+                ? $this->parseContact($response['Billing'])
+                : null,
+            'tech' => isset($response['Tech'])
+                ? $this->parseContact($response['Tech'])
+                : null,
+            'admin' => isset($response['Admin'])
+                ? $this->parseContact($response['Admin'])
+                : null,
+            'ns' => NameserversResult::create($this->parseNameservers($response['NameServers'])),
+            'created_at' => isset($response['Created']) ? Utils::formatDate($response['Created']) : null,
+            'updated_at' => null,
+            'expires_at' => isset($response['Expires']) ? Utils::formatDate($response['Expires']) : null,
+        ];
+    }
+
+
+    private function parseNameservers(array $nameservers): array
+    {
+        $result = [];
+
+        for ($i = 1; $i <= self::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if ($nameservers["NameServer{$i}"]['HostName'] !== null) {
+                $result['ns' . $i] = [
+                    'host' => (string)$nameservers["NameServer{$i}"]['HostName'],
+                    'ip' => (string)$nameservers["NameServer{$i}"]['IpAddress']
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+
+    public function checkMultipleDomains(array $domains): array
+    {
+        $command = 'availabilityInfo';
+        $dacDomains = [];
+
+        foreach ($domains as $domain) {
+            $params = [
+                "DomainName" => $domain,
+                "Quality" => "QualityTest"
+            ];
+
+            $response = $this->makeRequest($command, $params, 'AvailabilityInfoResult');
+
+            $available = $response['ResultCode'] == 200 || $response['ResultCode'] == 203;
+
+            $dacDomains[] = DacDomain::create([
+                'domain' => $response['DomainName'],
+                'description' => sprintf(
+                    'Domain is %s to register',
+                    $available ? 'available' : 'not available'
+                ),
+                'tld' => Utils::getTld($response['DomainName']),
+                'can_register' => $available,
+                'can_transfer' => !$available,
+                'is_premium' => $response["DomainType"] == "Premium",
+            ]);
+        }
+
+        return $dacDomains;
+    }
+
+
+    public function renew(string $domainName, int $period): void
+    {
+        $command = 'createOrder';
+
+        $params = [
+            'Type' => "Renew",
+            'Domain' => [
+                'Name' => $domainName,
+            ],
+            'Period' => $period,
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+    }
+
+
+    /**
+     * @param string $domainName
+     * @param array $nameservers
+     * @return array
+     * @throws \SoapFault
+     */
+    public function updateNameservers(string $domainName, array $nameservers): array
+    {
+        $command = 'createOrder';
+
+        $params = [
+            'Type' => "NameserverUpdate",
+            'Domain' => [
+                'Name' => $domainName,
+                "NameServers" => $nameservers
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+
+        $response = $this->getDomains($domainName);
+        return $this->parseNameservers($response['NameServers']);
+    }
+
+
+    /**
+     * @param string $domainName
+     * @return void
+     * @throws \SoapFault
+     */
+    public function setRenewalMode(string $domainName): void
+    {
+        $command = 'createOrder';
+
+        $params = [
+            'Type' => "AutoRenew",
+            'Domain' => [
+                'Name' => $domainName,
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+    }
+
+
+    public function setRegistrarLock(string $domainName, bool $lock): void
+    {
+        $command = 'createOrder';
+
+        $status = $lock ? 'Lock' : 'Unlock';
+
+        $params = [
+            'Type' => "ChangeLocks",
+            'Domain' => [
+                'Name' => $domainName,
+                "TransferLock" => $status,
+                "UpdateLock" => $status
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+
+    }
+
+
+    /**
+     * @param string $domainName
+     * @return string|null
+     * @throws \SoapFault
+     */
+    public function getDomainEppCode(string $domainName): ?string
+    {
+        $response = $this->getDomains($domainName);
+
+        return $response['AuthInfo'] ?? null;
+    }
+
+
+    /**
+     * @throws \SoapFault
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     */
+    public function register(
+        string $domainName,
+        int    $period,
+        array  $contacts,
+        array  $nameServers
+    ): void
+    {
+        $command = 'createOrder';
+
+        $nameserverParams = [];
+        $i = 1;
+        foreach ($nameServers as $ns) {
+            $nameserverParams["NameServer{$i}"] = [
+                'HostName' => $ns,
+            ];
+            $i++;
+        }
+
+        $params = [
+            'Type' => 'Register',
+            'Domain' => (object) [
+                'Name' => $domainName,
+                'NameServers' => $nameserverParams,
+                'RenewPeriod' => $period,
+                'Owner' => new SoapVar(
+                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_REGISTRANT]],
+                    SOAP_ENC_OBJECT,
+                    'Registrant',
+                    'http://www.ascio.com/2013/02'
+                ),
+                'Admin' => new SoapVar(
+                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_ADMIN]],
+                    SOAP_ENC_OBJECT,
+                    'Contact',
+                    'http://www.ascio.com/2013/02'
+                ),
+                'Tech' => new SoapVar(
+                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_TECH]],
+                    SOAP_ENC_OBJECT,
+                    'Contact',
+                    'http://www.ascio.com/2013/02'
+                ),
+                'Billing' => new SoapVar(
+                    (object) ['Handle' => $contacts[self::CONTACT_TYPE_BILLING]],
+                    SOAP_ENC_OBJECT,
+                    'Contact',
+                    'http://www.ascio.com/2013/02'
+                ),
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+    }
+
+
+    /**
+     * @param string|null $name
+     *
+     * @return array
+     */
+    private function getNameParts(?string $name): array
+    {
+        $nameParts = explode(" ", $name);
+        $firstName = array_shift($nameParts);
+        $lastName = implode(" ", $nameParts);
+
+        return compact('firstName', 'lastName');
+    }
+
+
+    /**
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws NumberParseException|\SoapFault
+     */
+    public function updateRegistrantContact(string $domainName, ContactParams $registrantParams): ContactData
+    {
+        $command = 'createOrder';
+
+        $params = [
+            'Type' => "OwnerChange",
+            'Domain' => [
+                'Name' => $domainName,
+                "Owner" => [
+                    'Handle' => $this->createRegistrant($registrantParams),
+                ],
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+
+        return $this->getDomainInfo($domainName)['registrant'];
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws NumberParseException
+     */
+    private function setContactParams(ContactParams $contactParams): array
+    {
+        $nameParts = $this->getNameParts($contactParams->name ?? $contactParams->organisation);
+
+        return array_filter([
+            'FirstName' => $nameParts['firstName'],
+            'LastName' => $nameParts['lastName'] ?: $nameParts['firstName'],
+            'OrgName' => $contactParams->organisation ?: '',
+            'Address1' => $contactParams->address1,
+            'City' => $contactParams->city,
+            'State' => $contactParams->state,
+            'PostalCode' => $contactParams->postcode,
+            'CountryCode' => Utils::normalizeCountryCode($contactParams->country_code),
+            'Phone' => Utils::internationalPhoneToEpp($contactParams->phone),
+            'Email' => $contactParams->email,
+        ], fn($value) => $value !== null);
+    }
+
+    private function parseContact(array $contact): ContactData
+    {
+        return ContactData::create([
+            'organisation' => $contact['OrgName'] ?? null,
+            'name' => implode(' ', [$contact['FirstName'] ?? '', $contact['LastName'] ?? '']),
+            'address1' => $contact['Address1'] ?? null,
+            'city' => $contact['City'],
+            'state' => $contact['State'] ?? null,
+            'postcode' => $contact['PostalCode'] ?? null,
+            'country_code' => Utils::normalizeCountryCode($contact['CountryCode'] ?? null),
+            'email' => $contact['Email'] ?? null,
+            'phone' => $contact['Phone'] ?? null,
+        ]);
+    }
+
+
+    /**
+     * @throws \SoapFault
+     * @throws NumberParseException
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     */
+    public function initiateTransfer(string $domainName, string $eppCode, array $contacts, array $nameServers): void
+    {
+        $command = 'createOrder';
+
+        $nameserverParams = [];
+        $i = 1;
+        foreach ($nameServers as $ns) {
+            $nameserverParams["NameServer{$i}"] = [
+                'HostName' => $ns,
+            ];
+            $i++;
+        }
+
+        $params = [
+            'Type' => 'Transfer',
+            'Domain' => (object) [
+                'Name' => $domainName,
+                'NameServers' => $nameserverParams,
+                'AuthInfo' => $eppCode,
+                'Owner' => new SoapVar(
+                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_REGISTRANT]),
+                    SOAP_ENC_OBJECT,
+                    'Registrant',
+                    'http://www.ascio.com/2013/02'
+                ),
+                'Admin' => new SoapVar(
+                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_ADMIN]),
+                    SOAP_ENC_OBJECT,
+                    'Contact',
+                    'http://www.ascio.com/2013/02'
+                ),
+                'Tech' => new SoapVar(
+                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_TECH]),
+                    SOAP_ENC_OBJECT,
+                    'Contact',
+                    'http://www.ascio.com/2013/02'
+                ),
+                'Billing' => new SoapVar(
+                    (object) $this->setContactParams($contacts[self::CONTACT_TYPE_BILLING]),
+                    SOAP_ENC_OBJECT,
+                    'Contact',
+                    'http://www.ascio.com/2013/02'
+                ),
+            ],
+        ];
+
+        $this->makeRequest($command, $params, 'CreateOrderResult');
+    }
+
+    /**
+     * Resend verification email for a domain.
+     *
+     * @param string $domainName Full domain name (e.g., example.com)
+     * @return array Success result
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError|\SoapFault
+     */
+    public function resendVerificationEmail(string $domainName): array
+    {
+        $domainData = $this->getDomains($domainName);
+        $email = $domainData['Owner']['Email'];
+
+        $command = 'startRegistrantVerification';
+        $params = [
+            "Email" => $email,
+        ];
+
+        $response = $this->makeRequest($command, $params, 'StartRegistrantVerificationResult');
+
+        return [
+            'success' => true,
+            'message' => $response['ResultMessage'] ?? 'Verification email sent successfully',
+        ];
+
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError|\SoapFault
+     */
+    public function poll(int $limit, ?Carbon $since): array
+    {
+        $notifications = [];
+        $countRemaining = 0;
+
+        /**
+         * Start a timer because there may be 1000s of irrelevant messages and we should try and avoid a timeout.
+         */
+        $timeLimit = 60; // 60 seconds
+        $startTime = time();
+
+        while (count($notifications) < $limit && (time() - $startTime) < $timeLimit) {
+            $pollResponse = $this->makeRequest('pollQueue', [
+                'MessageType' => 'MessageToPartner',
+                'ObjectType' => 'DomainType'
+            ], 'PollQueueResult');
+
+            $countRemaining = $pollResponse['TotalCount'] ?? 0;
+
+            if ($countRemaining == 0) {
+                break;
+            }
+
+            $messageId = $pollResponse['Message']['Id'] ?? null;
+
+            if ($messageId == null) {
+                continue;
+            }
+
+            $message = $pollResponse['Message']['Message'] ?: 'Domain Notification';
+            $domain = $pollResponse['Message']['ObjectName'];
+
+            $type = "";
+
+            switch ($pollResponse['Message']['OrderType']) {
+                case 'Transfer':
+                case 'Register':
+                    $type = DomainNotification::TYPE_TRANSFER_IN;
+                    break;
+                case 'TransferAway':
+                    $type = DomainNotification::TYPE_TRANSFER_OUT;
+                    break;
+                case 'Delete':
+                    $type = DomainNotification::TYPE_DELETED;
+                    break;
+                case 'Renew':
+                    $type = DomainNotification::TYPE_RENEWED;
+                    break;
+            }
+
+            try {
+                $this->makeRequest('ackQueueMessage', [
+                    "MessageId" => $messageId,
+                ], 'AckQueueMessageResult');
+            } catch (Throwable $e) {
+                continue;
+            }
+
+            $messageDateTime = carbon::now();
+
+            $orderId = $pollResponse['Message']['OrderId'];
+            try {
+                $order = $this->makeRequest('getMessages', [
+                    "OrderId" => $orderId,
+                ], 'GetMessagesResult');
+
+                $messageDateTime = Carbon::parse($order['Messages']['Message'][0]['Created']);
+            } catch (Throwable $e) {
+                continue;
+            }
+
+            if ($type == "") {
+                continue;
+            }
+
+            if (isset($since) && $messageDateTime->lessThan($since)) {
+                // this message is too old
+                continue;
+            }
+
+
+            $notifications[] = DomainNotification::create()
+                ->setId($messageId)
+                ->setType($type)
+                ->setMessage($message)
+                ->setDomains([$domain])
+                ->setCreatedAt($messageDateTime)
+                ->setExtra(['response' => json_encode($pollResponse['Message'])]);
+        }
+
+        return [
+            'count_remaining' => $countRemaining,
+            'notifications' => $notifications,
+        ];
+    }
+
+    /**
+     * @throws \SoapFault
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws NumberParseException
+     */
+    public function createContact(ContactParams $contactParams): ?string
+    {
+        $command = 'createContact';
+
+        $params = [
+            'Contact' => $this->setContactParams($contactParams)
+        ];
+
+        return $this->makeRequest($command, $params, 'CreateContactResult')['Contact']['Handle'] ?? null;
+    }
+
+
+    /**
+     * @throws \SoapFault
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws NumberParseException
+     */
+    public function createRegistrant(ContactParams $contactParams): ?string
+    {
+        $command = 'createRegistrant';
+
+        $params = [
+            'Registrant' => $this->setContactParams($contactParams)
+        ];
+
+        return $this->makeRequest($command, $params, 'CreateRegistrantResult')['Registrant']['Handle'] ?? null;
+    }
+}

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -179,7 +179,10 @@ class AscioApi
         return [
             'id' => $response['DomainHandle'],
             'domain' => (string)$response['DomainName'],
-            'statuses' => [$response['Status']],
+            'statuses' => array_values(array_filter(array_map(
+                'trim',
+                explode(',', (string)($response['Status'] ?? ''))
+            ), 'strlen')),
             'locked' => $response['TransferLock'] == 'Lock' && $response['UpdateLock'] == 'Lock',
             'registrant' => isset($response['Owner'])
                 ? $this->parseContact($response['Owner'])
@@ -353,7 +356,7 @@ class AscioApi
         int    $period,
         array  $contacts,
         array  $nameServers
-    ): void
+    ): array
     {
         $command = 'createOrder';
 
@@ -399,7 +402,7 @@ class AscioApi
             ],
         ];
 
-        $this->makeRequest($command, $params, 'CreateOrderResult');
+        return $this->makeRequest($command, $params, 'CreateOrderResult');
     }
 
 

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -488,7 +488,7 @@ class AscioApi
      * @throws NumberParseException
      * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
      */
-    public function initiateTransfer(string $domainName, string $eppCode, array $contacts, array $nameServers): void
+    public function initiateTransfer(string $domainName, string $eppCode, array $contacts, array $nameServers): array
     {
         $command = 'createOrder';
 
@@ -534,7 +534,7 @@ class AscioApi
             ],
         ];
 
-        $this->makeRequest($command, $params, 'CreateOrderResult');
+        return $this->makeRequest($command, $params, 'CreateOrderResult');
     }
 
     /**

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -125,13 +125,15 @@ class AscioApi
     }
 
 
-    private function getResponseErrorMessage(string $command, array $responseData)
+    private function getResponseErrorMessage(string $command, array $responseData): ?string
     {
-        if ($responseData['ResultCode'] !== 200 && $responseData['ResultCode'] !== 201) {
-            $errorMessage = $responseData['ResultMessage'];
+        $resultCode = $responseData['ResultCode'] ?? null;
+
+        if ($resultCode !== 200 && $resultCode !== 201) {
+            return $responseData['ResultMessage'] ?? 'Unknown Provider API Error';
         }
 
-        return $errorMessage ?? null;
+        return null;
     }
 
 

--- a/src/Ascio/Helper/AscioApi.php
+++ b/src/Ascio/Helper/AscioApi.php
@@ -82,7 +82,6 @@ class AscioApi
         $this->logger->debug('Ascio API Request', [
             'command' => $command,
             'params' => $requestParams,
-            'pass' => $this->client->__getLastRequestHeaders(),
         ]);
 
         $response = $this->client->__soapCall($command, array($requestParams));
@@ -90,10 +89,6 @@ class AscioApi
 
         $this->logger->debug('Ascio API Response', [
             'result' => $responseData,
-        ]);
-
-        $this->logger->debug('Ascio API header', [
-            'pass' => $this->client->__getLastRequest(),
         ]);
 
         return $this->parseResponseData($command, $response, $responseField)[$responseField];

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -1,0 +1,525 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Ascio;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use SoapHeader;
+use Throwable;
+use SoapClient;
+use SoapFault;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\Data\VerificationStatusParams;
+use Upmind\ProvisionProviders\DomainNames\Data\VerificationStatusResult;
+use Upmind\ProvisionProviders\DomainNames\Data\ResendVerificationParams;
+use Upmind\ProvisionProviders\DomainNames\Data\ResendVerificationResult;
+use Upmind\ProvisionProviders\DomainNames\Data\SetGlueRecordParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RemoveGlueRecordParams;
+use Upmind\ProvisionProviders\DomainNames\Data\GlueRecord;
+use Upmind\ProvisionProviders\DomainNames\Data\GlueRecordsResult;
+use Upmind\ProvisionProviders\DomainNames\Data\StatusResult;
+use Upmind\ProvisionProviders\DomainNames\Ascio\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\Ascio\Helper\AscioApi;
+
+class Provider extends DomainNames implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected Configuration $configuration;
+
+    /**
+     * @var AscioApi
+     */
+    protected AscioApi $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Ascio')
+            ->setDescription('Register, transfer, renew and manage domains')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/ascio-logo.png');
+    }
+
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+
+        $domains = array_map(
+            fn($tld) => $sld . "." . Utils::normalizeTld($tld),
+            $params->tlds
+        );
+
+        $dacDomains = $this->api()->checkMultipleDomains($domains);
+
+        return DacResult::create([
+            'domains' => $dacDomains,
+        ]);
+    }
+
+    public function poll(PollParams $params): PollResult
+    {
+        $since = $params->after_date ? Carbon::parse($params->after_date) : null;
+
+        try {
+            $poll = $this->api()->poll(intval($params->limit), $since);
+            return PollResult::create($poll);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $contacts = [
+            "registrant" => $params->registrant,
+            "admin" => $params->admin,
+            "tech" => $params->tech,
+            "billing" => $params->billing,
+        ];
+
+        try {
+            $contactsId = $this->getContactsId($contacts);
+
+            $this->api()->register(
+                $domainName,
+                intval($params->renew_years),
+                $contactsId,
+                $params->nameservers->pluckHosts(),
+            );
+
+            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $eppCode = $params->epp_code ?: '0000';
+
+        if (!Arr::has($params, 'registrant.register')) {
+            $this->errorResult('Registrant contact data is required!');
+        }
+
+        if (!Arr::has($params, 'admin.register')) {
+            $this->errorResult('Registrant contact data is required!');
+        }
+        if (!Arr::has($params, 'tech.register')) {
+            $this->errorResult('Registrant contact data is required!');
+        }
+        if (!Arr::has($params, 'billing.register')) {
+            $this->errorResult('Registrant contact data is required!');
+        }
+
+        if (!Arr::has($params, 'nameservers')) {
+            $this->errorResult('Nameservers is required!');
+        }
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (Throwable $e) {
+            // domain not active - continue below
+        }
+
+        $contacts = [
+            AscioApi::CONTACT_TYPE_REGISTRANT=> $params->registrant->register,
+            AscioApi::CONTACT_TYPE_ADMIN => $params->admin->register,
+            AscioApi::CONTACT_TYPE_TECH => $params->tech->register,
+            AscioApi::CONTACT_TYPE_BILLING => $params->billing->register,
+        ];
+
+        try {
+
+            $this->api()->initiateTransfer(
+                $domainName,
+                $eppCode,
+                $contacts,
+                $params['nameservers'],
+            );
+
+            $this->errorResult(sprintf('Transfer for %s domain successfully created!', $domainName), [
+                'transaction_id' => null
+            ]);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    /**
+     * @return array<string,int>|string[]
+     *
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getContactsId(array $params): array
+    {
+        if (Arr::has($params, 'registrant.id')) {
+            $registrantID = $params['registrant']['id'];
+        } else {
+            if (!Arr::has($params, 'registrant.register')) {
+                $this->errorResult('Registrant contact data is required!');
+            }
+            $registrantID = $this->api()->createRegistrant($params['registrant']['register']);
+        }
+
+        if (Arr::has($params, 'tech.id')) {
+            $techID = $params['tech']['id'];
+        } else {
+            if (!Arr::has($params, 'tech.register')) {
+                $this->errorResult('Tech contact data is required!');
+            }
+            $techID = $this->api()->createContact($params['tech']['register']);
+        }
+
+        if (Arr::has($params, 'admin.id')) {
+            $adminID = $params['admin']['id'];
+        } else {
+            if (!Arr::has($params, 'admin.register')) {
+                $this->errorResult('Admin contact data is required!');
+            }
+            $adminID = $this->api()->createContact($params['admin']['register']);
+        }
+
+        if (Arr::has($params, 'billing.id')) {
+            $billingID = $params['billing']['id'];
+        } else {
+            if (!Arr::has($params, 'billing.register')) {
+                $this->errorResult('Billing contact data is required!');
+            }
+
+            $billingID = $this->api()->createContact($params['billing']['register']);
+        }
+
+        return [
+            AscioApi::CONTACT_TYPE_REGISTRANT => $registrantID,
+            AscioApi::CONTACT_TYPE_ADMIN => $adminID,
+            AscioApi::CONTACT_TYPE_TECH => $techID,
+            AscioApi::CONTACT_TYPE_BILLING => $billingID,
+        ];
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $period = intval($params->renew_years);
+
+        try {
+            $this->api()->renew($domainName, $period);
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            return $this->_getInfo($domainName, 'Domain data obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    private function _getInfo(string $domainName, string $message): DomainResult
+    {
+        $domainInfo = $this->api()->getDomainInfo($domainName);
+
+        return DomainResult::create($domainInfo)->setMessage($message);
+    }
+
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $contact = $this->api()->updateRegistrantContact($domainName, $params->contact);
+
+            return ContactResult::create($contact);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $nameservers = [];
+
+        for ($i = 1; $i <= AscioApi::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'ns' . $i)) {
+                $nameservers["NameServer{$i}"] = [
+                    'HostName' => Arr::get($params, 'ns' . $i)->host,
+                    'IpAddress' => Arr::get($params, 'ns' . $i)->ip,
+                ];
+            }
+        }
+
+        try {
+            $result = $this->api()->updateNameservers(
+                $domainName,
+                $nameservers,
+            );
+
+            return NameserversResult::create($result)
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function setLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $lock = !!$params->lock;
+
+        try {
+            $domainData = $this->api()->getDomains($domainName);
+
+            if (!$lock && $domainData['TransferLock'] == "Unlock" && $domainData['UpdateLock'] !== "Unlock") {
+                return $this->_getInfo($domainName, sprintf('Domain %s already unlocked', $domainName));
+            }
+
+            if ($lock && $domainData['TransferLock'] == "Lock" && $domainData['UpdateLock'] !== "Lock") {
+                return $this->_getInfo($domainName, sprintf('Domain %s already locked', $domainName));
+            }
+
+            $this->api()->setRegistrarLock($domainName, $lock);
+
+            return $this->_getInfo($domainName, sprintf("Lock %s!", $lock ? 'enabled' : 'disabled'));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $autoRenew = !!$params->auto_renew;
+
+        if (!$autoRenew) {
+            $this->errorResult("Cannot unset domain auto-renew mode", $params);
+        }
+
+        try {
+            $this->api()->setRenewalMode($domainName);
+
+            return $this->_getInfo($domainName, 'Auto-renew mode updated');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $eppCode = $this->api()->getDomainEppCode($domainName);
+
+            return EppCodeResult::create([
+                'epp_code' => $eppCode,
+            ])->setMessage('EPP/Auth code obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getVerificationStatus(VerificationStatusParams $params): VerificationStatusResult
+    {
+        $this->errorResult('Operation not supported', $params);
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function resendVerificationEmail(ResendVerificationParams $params): ResendVerificationResult
+    {
+        try {
+            $domain = Utils::getDomain($params->sld, $params->tld);
+            $result = $this->api()->resendVerificationEmail($domain);
+
+            return ResendVerificationResult::create($result);
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    /**
+     * @return no-return
+     * @return never
+     * @throws Throwable
+     *
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if ($e instanceof SoapFault) {
+            $errorMessage = sprintf('Provider API Soap Error [%s]', $e->faultcode);
+            $errorData = [
+                'error' => [
+                    'exception' => get_class($e),
+                    'code' => $e->getCode(),
+                    'message' => $e->getMessage(),
+                    'soap_fault' => [
+                        'code' => $e->faultcode ?? null,
+                        'string' => $e->faultstring ?? null,
+                        'detail' => $e->detail ?? null,
+                        'actor' => $e->faultactor ?? null,
+                        'headerfault' => $e->headerfault ?? null,
+                    ],
+                ],
+            ];
+
+            if (Str::contains($e->getMessage(), 'Parsing WSDL')) {
+                $errorMessage = 'Provider API Soap Connection Error';
+            }
+
+            $this->errorResult($errorMessage, $errorData, [], $e);
+        }
+
+        throw $e;
+    }
+
+    protected function api(): AscioApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        // apparently the only way to set the actual timeout for SoapClient
+        // init_set sets the value and returns the old value.
+        $defaultTimeout = ini_set("default_socket_timeout", "5");
+
+        $options = [
+            'trace' => 1,
+            'soap_version' => SOAP_1_1,
+        ];
+
+        try {
+            $client = new SoapClient($this->resolveAPIURL(), $options);
+
+            $credentials = ["Account" => $this->configuration->username, "Password" => $this->configuration->password];
+            $headers = [];
+            $headers[] = new \SoapHeader("http://www.ascio.com/2013/02", "SecurityHeaderDetails", $credentials, false);
+            $headers[] = new \SoapHeader("http://www.ascio.com/2013/02", "ImpersonationHeaderDetails", null, false);
+            $client->__setSoapHeaders($headers);
+
+            return $this->api = new AscioApi($client, $this->configuration, $this->getLogger());
+        } catch (Throwable $e) {
+            $this->handleException($e);
+        } finally {
+            if ($defaultTimeout !== false) {
+                // restore the default timeout
+                ini_set("default_socket_timeout", $defaultTimeout);
+            }
+        }
+    }
+
+
+    private function resolveAPIURL(): string
+    {
+        return $this->configuration->sandbox
+            ? 'https://aws.demo.ascio.com/v3/aws.wsdl'
+            : 'https://aws.ascio.com/v3/aws.wsdl';
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function setGlueRecord(SetGlueRecordParams $params): GlueRecordsResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function removeGlueRecord(RemoveGlueRecordParams $params): GlueRecordsResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatus(DomainInfoParams $params): StatusResult
+    {
+
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $domainData = $this->_getInfo($domainName, "");
+            $status = StatusResult::STATUS_UNKNOWN;
+            switch ($domainData->statuses[0]) {
+                case "Active":
+                    $status = StatusResult::STATUS_ACTIVE;
+                    break;
+                case "Deleted":
+                    $status = StatusResult::STATUS_CANCELLED;
+
+            }
+
+            return StatusResult::create()
+                ->setStatus($status)
+                ->setExpiresAt($domainData->expires_at
+                    ? new \DateTimeImmutable($domainData->expires_at)
+                    : null)
+                ->setRawStatuses($domainData->statuses);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+}

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -11,6 +11,7 @@ use SoapHeader;
 use Throwable;
 use SoapClient;
 use SoapFault;
+use UnexpectedValueException;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
@@ -293,7 +294,7 @@ class Provider extends DomainNames implements ProviderInterface
     {
         try {
             $contactType = $params->getContactTypeEnum();
-        } catch (UnexpectedValueException $ex) {
+        } catch (UnexpectedValueException) {
             $this->errorResult('Invalid contact type: ' . $params->contact_type);
         }
 
@@ -304,7 +305,7 @@ class Provider extends DomainNames implements ProviderInterface
 
             return ContactResult::create($contact);
         } catch (Throwable $e) {
-            $this->handleException($e, $params);
+            $this->handleException($e);
         }
     }
 

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -118,14 +118,32 @@ class Provider extends DomainNames implements ProviderInterface
         try {
             $contactsId = $this->getContactsId($contacts);
 
-            $this->api()->register(
+            $order = $this->api()->register(
                 $domainName,
                 intval($params->renew_years),
                 $contactsId,
                 $params->nameservers->pluckHosts(),
             );
 
-            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+            // createOrder is the authoritative success signal - non-200 ResultCodes throw in
+            // makeRequest, so reaching here means the registry accepted the order. Registration is
+            // async (the domain isn't queryable yet), so build the result from the order itself;
+            // syncStatus/getStatus backfills live status, expiry and contacts once it provisions.
+            $orderInfo = $order['OrderInfo'] ?? [];
+
+            return DomainResult::create()
+                ->setId($domainName)
+                ->setDomain($domainName)
+                ->setStatuses([$orderInfo['Status'] ?? 'Pending'])
+                ->setNs($params->nameservers)
+                ->setCreatedAt(null)
+                ->setUpdatedAt(null)
+                ->setExpiresAt(null)
+                ->setMessage(sprintf(
+                    'Domain %s registration submitted (order %s)',
+                    $domainName,
+                    $orderInfo['OrderId'] ?? 'pending'
+                ));
         } catch (\Throwable $e) {
             $this->handleException($e);
         }
@@ -549,14 +567,19 @@ class Provider extends DomainNames implements ProviderInterface
 
         try {
             $domainData = $this->_getInfo($domainName, "");
-            $status = StatusResult::STATUS_UNKNOWN;
-            switch ($domainData->statuses[0]) {
-                case "Active":
-                    $status = StatusResult::STATUS_ACTIVE;
-                    break;
-                case "Deleted":
-                    $status = StatusResult::STATUS_CANCELLED;
 
+            // Ascio returns a combinable set of statuses (split into individual values upstream).
+            // Map conservatively: only Deleted drives a downstream cancellation; Active/Expiring are
+            // live; anything else (Pending_Verification, Parked, Pending, Queue, ...) is not
+            // confirmable as active -> unknown, with the raw values preserved for visibility.
+            $normalized = array_map(static fn ($s) => strtolower(trim((string)$s)), $domainData->statuses);
+
+            if (in_array('deleted', $normalized, true)) {
+                $status = StatusResult::STATUS_CANCELLED;
+            } elseif (array_intersect(['active', 'expiring'], $normalized)) {
+                $status = StatusResult::STATUS_ACTIVE;
+            } else {
+                $status = StatusResult::STATUS_UNKNOWN;
             }
 
             return StatusResult::create()

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -588,6 +588,26 @@ class Provider extends DomainNames implements ProviderInterface
                     ? new \DateTimeImmutable($domainData->expires_at)
                     : null)
                 ->setRawStatuses($domainData->statuses);
+        } catch (ProvisionFunctionError $e) {
+            if (str_contains($e->getMessage(), 'Domain not found')) {
+                // Domain isn't in our account - distinguish "we lost it" (still available at
+                // registry => cancelled/dropped) from "someone else has it" (taken =>
+                // transferred away). Mirrors the Enom/LogicBoxes pattern.
+                try {
+                    $check = $this->api()->checkMultipleDomains([$domainName]);
+
+                    return StatusResult::create()
+                        ->setStatus($check[0]->can_register
+                            ? StatusResult::STATUS_CANCELLED
+                            : StatusResult::STATUS_TRANSFERRED_AWAY)
+                        ->setExpiresAt(null)
+                        ->setExtra(['availability_check' => $check[0]->toArray()]);
+                } catch (\Throwable $checkException) {
+                    // DAC failed too - surface the original "not found" error.
+                    $this->handleException($e);
+                }
+            }
+            $this->handleException($e);
         } catch (\Throwable $e) {
             $this->handleException($e);
         }

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -568,25 +568,36 @@ class Provider extends DomainNames implements ProviderInterface
         try {
             $domainData = $this->_getInfo($domainName, "");
 
-            // Ascio returns a combinable set of statuses (split into individual values upstream).
-            // Map conservatively: only Deleted drives a downstream cancellation; Active/Expiring are
-            // live; anything else (Pending_Verification, Parked, Pending, Queue, ...) is not
-            // confirmable as active -> unknown, with the raw values preserved for visibility.
+            // Status mapping: date-dominant for active/expired (the pattern used by the other
+            // "real" implementations in this package - Enom/LogicBoxes/OpenSRS), with raw-status
+            // overrides for terminal (`Deleted`) and "not yet usable" (`Pending_Verification`
+            // without `Active`/`Expiring`) cases. The raw statuses are surfaced via setRawStatuses
+            // so operators see the original Ascio strings.
             $normalized = array_map(static fn ($s) => strtolower(trim((string)$s)), $domainData->statuses);
+            $expiresAt = $domainData->expires_at
+                ? new \DateTimeImmutable($domainData->expires_at)
+                : null;
 
             if (in_array('deleted', $normalized, true)) {
+                // Explicit terminal: registry flagged the domain as gone.
                 $status = StatusResult::STATUS_CANCELLED;
-            } elseif (array_intersect(['active', 'expiring'], $normalized)) {
-                $status = StatusResult::STATUS_ACTIVE;
-            } else {
+            } elseif (
+                in_array('pending_verification', $normalized, true)
+                && !array_intersect(['active', 'expiring'], $normalized)
+            ) {
+                // In our account but not yet resolving (ICANN email verification outstanding).
                 $status = StatusResult::STATUS_UNKNOWN;
+            } elseif ($expiresAt !== null && $expiresAt < new \DateTimeImmutable()) {
+                // Past expiry - catches `Pending_Auction` and any case where Ascio is slow to
+                // flip the status flag away from `Active` after expiration.
+                $status = StatusResult::STATUS_EXPIRED;
+            } else {
+                $status = StatusResult::STATUS_ACTIVE;
             }
 
             return StatusResult::create()
                 ->setStatus($status)
-                ->setExpiresAt($domainData->expires_at
-                    ? new \DateTimeImmutable($domainData->expires_at)
-                    : null)
+                ->setExpiresAt($expiresAt)
                 ->setRawStatuses($domainData->statuses);
         } catch (ProvisionFunctionError $e) {
             if (str_contains($e->getMessage(), 'Domain not found')) {

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -178,9 +178,14 @@ class Provider extends DomainNames implements ProviderInterface
         }
 
         try {
+            // if the domain is already active in our account the transfer has completed
             return $this->_getInfo($domainName, 'Domain active in registrar account');
-        } catch (Throwable $e) {
-            // domain not active - continue below
+        } catch (ProvisionFunctionError $e) {
+            if (!$this->isDomainNotFound($e)) {
+                // a genuine error (network/auth/etc) - don't mistake it for "not transferred yet"
+                $this->handleException($e);
+            }
+            // domain not yet in our account - continue below to initiate the transfer
         }
 
         $contacts = [
@@ -192,15 +197,15 @@ class Provider extends DomainNames implements ProviderInterface
 
         try {
 
-            $this->api()->initiateTransfer(
+            $result = $this->api()->initiateTransfer(
                 $domainName,
                 $eppCode,
                 $contacts,
                 $params['nameservers'],
             );
 
-            $this->errorResult(sprintf('Transfer for %s domain successfully created!', $domainName), [
-                'transaction_id' => null
+            $this->errorResult(sprintf('Transfer for %s initiated', $domainName), [
+                'result' => $result,
             ]);
         } catch (\Throwable $e) {
             $this->handleException($e);
@@ -467,6 +472,19 @@ class Provider extends DomainNames implements ProviderInterface
 
 
     /**
+     * Determine whether the given exception represents a "domain not in our account" result.
+     *
+     * This matches the literal message thrown by AscioApi::getDomains() when the registry
+     * returns a successful response containing no domain data - not any string returned by
+     * Ascio itself - so the two call sites (getStatus + transfer) stay in sync.
+     */
+    private function isDomainNotFound(Throwable $e): bool
+    {
+        return $e instanceof ProvisionFunctionError
+            && Str::contains($e->getMessage(), 'Domain not found');
+    }
+
+    /**
      * @return no-return
      * @return never
      * @throws Throwable
@@ -603,7 +621,7 @@ class Provider extends DomainNames implements ProviderInterface
                 ->setExpiresAt($expiresAt)
                 ->setRawStatuses($domainData->statuses);
         } catch (ProvisionFunctionError $e) {
-            if (str_contains($e->getMessage(), 'Domain not found')) {
+            if ($this->isDomainNotFound($e)) {
                 // Domain isn't in our account - distinguish "we lost it" (still available at
                 // registry => cancelled/dropped) from "someone else has it" (taken =>
                 // transferred away). Mirrors the Enom/LogicBoxes pattern.

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -139,6 +139,9 @@ class Provider extends DomainNames implements ProviderInterface
                 ->setCreatedAt(null)
                 ->setUpdatedAt(null)
                 ->setExpiresAt(null)
+                // registration is async - signal to the caller that this result is not yet final so
+                // it can schedule a later info pull to backfill live status, expiry and contacts
+                ->setOperationStatus(DomainResult::OPERATION_IN_PROGRESS)
                 ->setMessage(sprintf(
                     'Domain %s registration submitted (order %s)',
                     $domainName,

--- a/src/Ascio/Provider.php
+++ b/src/Ascio/Provider.php
@@ -320,8 +320,8 @@ class Provider extends DomainNames implements ProviderInterface
     {
         try {
             $contactType = $params->getContactTypeEnum();
-        } catch (UnexpectedValueException) {
-            $this->errorResult('Invalid contact type: ' . $params->contact_type);
+        } catch (UnexpectedValueException $e) {
+            $this->errorResult('Invalid contact type: ' . $params->contact_type, [], [], $e);
         }
 
         $domainName = Utils::getDomain($params->sld, $params->tld);

--- a/src/Data/DomainResult.php
+++ b/src/Data/DomainResult.php
@@ -26,9 +26,21 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string $created_at Date of creation in format - Y-m-d H:i:s
  * @property-read string $updated_at Date of last update in format - Y-m-d H:i:s
  * @property-read string $expires_at Date of domain renewing in format - Y-m-d H:i:s
+ * @property-read string|null $operation_status Status of an async operation, if still resolving; one of the OPERATION_* constants
  */
 class DomainResult extends ResultData
 {
+    /**
+     * The operation was accepted but is still resolving asynchronously; the returned data may be
+     * incomplete and the caller should query again later (e.g. an async register or transfer).
+     */
+    public const OPERATION_IN_PROGRESS = 'in_progress';
+
+    /**
+     * The operation has completed and the returned data reflects the final state.
+     */
+    public const OPERATION_COMPLETE = 'complete';
+
     public static function rules(): Rules
     {
         return new Rules([
@@ -51,6 +63,7 @@ class DomainResult extends ResultData
             'created_at' => ['present', 'nullable', 'date_format:Y-m-d H:i:s'],
             'updated_at' => ['present', 'nullable', 'date_format:Y-m-d H:i:s'],
             'expires_at' => ['present', 'nullable', 'date_format:Y-m-d H:i:s'],
+            'operation_status' => ['nullable', 'string', 'in:' . self::OPERATION_IN_PROGRESS . ',' . self::OPERATION_COMPLETE],
         ]);
     }
 
@@ -182,6 +195,19 @@ class DomainResult extends ResultData
     public function setGlueRecords($glueRecords)
     {
         $this->setValue('glue_records', $glueRecords);
+        return $this;
+    }
+
+    /**
+     * Indicate whether an async operation (e.g. register/transfer) is still resolving.
+     *
+     * @param string|null $operationStatus One of the OPERATION_* constants, or null if not applicable
+     *
+     * @return static $this
+     */
+    public function setOperationStatus(?string $operationStatus)
+    {
+        $this->setValue('operation_status', $operationStatus);
         return $this;
     }
 }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -40,6 +40,7 @@ use Upmind\ProvisionProviders\DomainNames\Netim\Provider as Netim;
 use Upmind\ProvisionProviders\DomainNames\Netistrar\Provider as Netistrar;
 use Upmind\ProvisionProviders\DomainNames\BDReseller\Provider as BDReseller;
 use Upmind\ProvisionProviders\DomainNames\OpusDNS\Provider as OpusDNS;
+use Upmind\ProvisionProviders\DomainNames\Ascio\Provider as Ascio;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -83,5 +84,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'netistrar', Netistrar::class);
         $this->bindProvider('domain-names', 'bd-reseller', BDReseller::class);
         $this->bindProvider('domain-names', 'opus-dns', OpusDNS::class);
+        $this->bindProvider('domain-names', 'ascio', Ascio::class);
     }
 }


### PR DESCRIPTION
ATBE-770. Adds the Ascio (v3 SOAP) domain registrar provider. Carries forward the implementation from #209 (originally by @CodeLineFi) with two correctness fixes applied during review.

## Fixes vs. #209

**`register()` reported failure on successful async orders.** Ascio's `createOrder` returns `Status: "Validated"` asynchronously — the domain isn't queryable immediately. The previous code did an immediate `getInfo` read-back which threw `"Domain not found"` and surfaced a successful, charged registration as a failure (and left the contract product stuck in `awaiting_activation`). `register()` now builds the result from the `createOrder` response itself; `syncStatus`/`getStatus` backfills live status, expiry and contacts once the domain provisions.

**`getStatus()` didn't handle Ascio's compound status taxonomy.** Ascio returns combinable, comma-joined statuses (e.g. `"Pending_Verification, Parked"`). `parseDomainData()` now splits them into individual values; `getStatus()` maps the set conservatively (`Deleted` → cancelled, `Active`/`Expiring` → active, else `unknown`) so transient pending states never trigger a downstream `syncStatus` cancellation.

## Verified

- `getStatus` live: `swisse.lu` → `active` `["Active"]`; `upmindtesting.com` → `unknown` `["Pending_Verification","Parked"]` (split correct, expiry surfaced).
- `register` Option B end-to-end verification pending (re-test blocked on intermittent Ascio IP-allowlist auth).
- PHPStan clean on the changed lines.

## Out of scope here

- Credential / PII logging in the SOAP debug trace.
- Pre-existing PHPStan errors in `updateContact` (`ContactType::equals()` / `getValue()`) — may be vendor-version skew.
- Admin / Tech / Billing contact persistence on `.com` registration — Ascio appears to discard non-Owner contacts; needs Ascio support clarification, may not be a code fix.