### PR TITLE
CentralNicReseller expiry date should use Paid Until date

### DIFF
--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -697,9 +697,9 @@ class EppHelper
     }
 
     /**
-     * Get the domain renewal date from the EPP response.
+     * Get the domain expiration date from the EPP response.
      *
-     * CentralNic Reseller uses the keysys:renDate as the authoritative date for
+     * CentralNic Reseller uses the keysys:punDate as the authoritative date for
      * automated renewal or deletion. This date must always be present and is the
      * only date that should be used for expiration tracking.
      *
@@ -707,17 +707,17 @@ class EppHelper
      */
     private function getDomainExpirationDateFromResponse(eppResponse $response): string
     {
-        $renewalDate = $response->queryPath(
-            '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:renDate'
+        $paidUntilDate = $response->queryPath(
+            '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:punDate'
         );
 
-        if ($renewalDate === null) {
+        if ($paidUntilDate === null) {
             throw new ProvisionFunctionError(
-                'Renewal date (keysys:renDate) not found in EPP response'
+                'Paid Until date (keysys:punDate) not found in EPP response'
             );
         }
 
-        return $renewalDate;
+        return $paidUntilDate;
     }
 
     /**

--- a/src/CentralNicReseller/Provider.php
+++ b/src/CentralNicReseller/Provider.php
@@ -290,13 +290,6 @@ class Provider extends DomainNames implements ProviderInterface
     {
         $domainInfo = $this->epp()->getDomainInfo($domain);
 
-        /* Get the date that the domain is paid until, after this date the grace period will start  */
-        $paidUntil = $this->api()->statusDomain($domain)['PROPERTY']['PAIDUNTILDATE'][0] ?? null;
-        
-        if ($paidUntil) {
-            $domainInfo['expires_at'] = Utils::formatDate($paidUntil);
-        }
-
         return DomainResult::create($domainInfo, false)->setMessage($msg);
     }
 

--- a/src/CentralNicReseller/Provider.php
+++ b/src/CentralNicReseller/Provider.php
@@ -290,6 +290,13 @@ class Provider extends DomainNames implements ProviderInterface
     {
         $domainInfo = $this->epp()->getDomainInfo($domain);
 
+        /* Get the date that the domain is paid until, after this date the grace period will start  */
+        $paidUntil = $this->api()->statusDomain($domain)['PROPERTY']['PAIDUNTILDATE'][0] ?? null;
+        
+        if ($paidUntil) {
+            $domainInfo['expires_at'] = Utils::formatDate($paidUntil);
+        }
+
         return DomainResult::create($domainInfo, false)->setMessage($msg);
     }
 
@@ -611,8 +618,8 @@ class Provider extends DomainNames implements ProviderInterface
             $response = $this->api()->statusDomain($domainName);
 
             $statuses = $response['PROPERTY']['STATUS'] ?? [];
-            $expiresAt = isset($response['PROPERTY']['REGISTRATIONEXPIRATIONDATE'][0])
-                ? Carbon::parse($response['PROPERTY']['REGISTRATIONEXPIRATIONDATE'][0])
+            $expiresAt = isset($response['PROPERTY']['PAIDUNTILDATE'][0])
+                ? Carbon::parse($response['PROPERTY']['PAIDUNTILDATE'][0])
                 : null;
 
             // Check status codes for non-active states

--- a/src/Nominet/Provider.php
+++ b/src/Nominet/Provider.php
@@ -819,6 +819,7 @@ class Provider extends DomainNames implements ProviderInterface
         $nameservers = $response->getDomainNameservers();
         if (isset($nameservers)) {
             foreach ($nameservers as $i => $nameserver) {
+                /** @var array<string>|null $ips */
                 $ips = $nameserver->getIpAddresses();
                 $returnNs['ns' . ($i + 1)] = [
                     "host" => trim($nameserver->getHostname(), '.'),

--- a/src/Nominet/Provider.php
+++ b/src/Nominet/Provider.php
@@ -822,7 +822,7 @@ class Provider extends DomainNames implements ProviderInterface
                 $ips = $nameserver->getIpAddresses();
                 $returnNs['ns' . ($i + 1)] = [
                     "host" => trim($nameserver->getHostname(), '.'),
-                    "ip" => isset($ips) ? array_shift($ips) : null,
+                    "ip" => is_array($ips) ? array_shift($ips) : null,
                 ];
             }
         }


### PR DESCRIPTION
- Fixed CentralNicReseller expiry date to use Paid Until date instead of registry date which included a grace period