### PR TITLE
NameSilo - registrant info replaced on registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the package will be documented in this file.
 
+## Unreleased
+
+- Update NameSilo to associate multiple contacts with a domain in a single API call
+- Update NameSilo Configuration, allow handling sandbox API calls
+- Update NameSilo getInfo() to return the `whois_privacy` status of a domain correctly.
+
 ## [v2.30.3](https://github.com/upmind-automation/provision-provider-domain-names/releases/tag/v2.30.3) - 2026-05-11
 
 - Send `state` in Enom create/update requests

--- a/src/NameSilo/Data/NameSiloConfiguration.php
+++ b/src/NameSilo/Data/NameSiloConfiguration.php
@@ -11,6 +11,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * NameSilo configuration
  *
  * @property-read string $api_key API key
+ * @property-read bool|null $sandbox Make API requests against the sandbox environment
  */
 class NameSiloConfiguration extends DataSet
 {
@@ -18,6 +19,12 @@ class NameSiloConfiguration extends DataSet
     {
         return new Rules([
             'api_key' => ['required', 'string'],
+            'sandbox' => ['nullable', 'boolean'],
         ]);
+    }
+
+    public function isSandbox(): bool
+    {
+        return (bool) $this->sandbox;
     }
 }

--- a/src/NameSilo/Provider.php
+++ b/src/NameSilo/Provider.php
@@ -1121,6 +1121,8 @@ class Provider extends DomainNames implements ProviderInterface
     }
 
     /**
+     * @param array<string, string|int>$contactIds
+     *
      * @throws \Throwable
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */

--- a/src/NameSilo/Provider.php
+++ b/src/NameSilo/Provider.php
@@ -1114,7 +1114,9 @@ class Provider extends DomainNames implements ProviderInterface
         }
 
         return $this->client = new Client([
-            'base_uri' => 'https://www.namesilo.com/api/',
+            'base_uri' => $this->configuration->isSandbox()
+                ? 'https://ote.namesilo.com/api/'
+                : 'https://www.namesilo.com/api/',
             'handler' => $this->getGuzzleHandlerStack(),
         ]);
     }

--- a/src/NameSilo/Provider.php
+++ b/src/NameSilo/Provider.php
@@ -1134,6 +1134,8 @@ class Provider extends DomainNames implements ProviderInterface
             // No action for empty data, or invalid contact types.
             if (empty($contactId) || !$this->isValidProviderContactType($type)) {
                 unset($contactIds[$type]);
+
+                continue;
             }
 
             $data[$type] = $contactId;

--- a/src/NameSilo/Provider.php
+++ b/src/NameSilo/Provider.php
@@ -947,6 +947,7 @@ class Provider extends DomainNames implements ProviderInterface
             'domain' => $domainName,
             'statuses' => [(string)$domainData->reply->status],
             'locked' => ((string) $domainData->reply->locked) == 'Yes' ? true : false,
+            'whois_privacy' => (string) $domainData->reply->private === 'Yes',
             'renew' => ((string) $domainData->reply->auto_renew) == 'Yes' ? true : false,
             'registrant' => $contacts['registrant'],
             'billing' => $contacts['billing'],

--- a/src/NameSilo/Provider.php
+++ b/src/NameSilo/Provider.php
@@ -155,9 +155,7 @@ class Provider extends DomainNames implements ProviderInterface
 
         $this->_callApi($data, 'registerDomain');
 
-        foreach ($contactIds as $type => $contactId) {
-            $this->_associateContact($domain, (string)$contactId, $type);
-        }
+        $this->associateMultipleContacts($domain, $contactIds);
 
         $this->_addRegisteredNameServer($params);
         return $this->_getDomain($domain, 'Domain registered - ' . $domain);
@@ -1126,6 +1124,28 @@ class Provider extends DomainNames implements ProviderInterface
      * @throws \Throwable
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
+    private function associateMultipleContacts(string $domain, array $contactIds): void
+    {
+        $data = [
+            'domain' => $domain,
+        ];
+
+        foreach ($contactIds as $type => $contactId) {
+            // No action for empty data, or invalid contact types.
+            if (empty($contactId) || !$this->isValidProviderContactType($type)) {
+                unset($contactIds[$type]);
+            }
+
+            $data[$type] = $contactId;
+        }
+
+        $this->_callApi($data, 'contactDomainAssociate');
+    }
+
+    /**
+     * @throws \Throwable
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     private function _associateContact(string $domain, string $contactId, string $associateType): void
     {
         $this->_callApi([
@@ -1312,5 +1332,15 @@ class Provider extends DomainNames implements ProviderInterface
             default:
                 $this->errorResult('Invalid contact type: ' . $contactType->getValue());
         }
+    }
+
+    private function isValidProviderContactType(string $providerContactType): bool
+    {
+        return in_array($providerContactType, [
+            self::CONTACT_TYPE_REGISTRANT,
+            self::CONTACT_TYPE_ADMIN,
+            self::CONTACT_TYPE_BILLING,
+            self::CONTACT_TYPE_TECH,
+        ], true);
     }
 }

--- a/src/Nominet/Provider.php
+++ b/src/Nominet/Provider.php
@@ -819,6 +819,7 @@ class Provider extends DomainNames implements ProviderInterface
         $nameservers = $response->getDomainNameservers();
         if (isset($nameservers)) {
             foreach ($nameservers as $i => $nameserver) {
+                /** @var array<string>|null $ips */
                 $ips = $nameserver->getIpAddresses();
                 $returnNs['ns' . ($i + 1)] = [
                     "host" => trim($nameserver->getHostname(), '.'),

--- a/src/Nominet/Provider.php
+++ b/src/Nominet/Provider.php
@@ -822,7 +822,7 @@ class Provider extends DomainNames implements ProviderInterface
                 $ips = $nameserver->getIpAddresses();
                 $returnNs['ns' . ($i + 1)] = [
                     "host" => trim($nameserver->getHostname(), '.'),
-                    "ip" => isset($ips) ? array_shift($ips) : null,
+                    "ip" => is_array($ips) ? array_shift($ips) : null,
                 ];
             }
         }


### PR DESCRIPTION
The current flow when registering a domain is:

﻿﻿1. Check if domain can be registered with “checkRegisterAvailability", and throw error if it is not available
2. Create 4 contacts with “contactAdd”, one for each type, `registrant`, `administrative`, `technical`, `billing`
3. Register domain with “registerDomain” without contacts added
4. Link new contact IDs with their relevant type to the domain with “contactDomainAssociate”

However, in the 4th step, 4 consecutive calls are made to the endpoint, to update each contact individually.
Because the operation on NameSilo is asychronous, according to NameSilo

```
Domain updates can take a few seconds to complete, therefore if you are making consecutive changes these can be skipped as the domain status may be locked for processing initial changes.
```


Furthermore, the configuration file did not allow for sandbox handling
And also, whois privacy flag was not returned

-----

## Updates for NameSIlo

- Single API request, with all 4 contacts included, removing empty/not-valid, to `contactDomainAssociate` endpoint on `register` method
- Added `sandbox` configuration param
- Retrieve `private` flag from domain info to use for `whois_privacy` flag