### PR TITLE
v2.12 - CentralNicReseller expiry date should use Paid Until date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-soap": "*",
         "ext-xml": "*",
         "upmind/provision-provider-base": "^3.7",
-        "metaregistrar/php-epp-client": "^1.0.12",
+        "metaregistrar/php-epp-client": "1.0.13",
         "myclabs/php-enum": "^1.8",
         "propaganistas/laravel-phone": "^4.2",
         "guzzlehttp/guzzle": "^6.3|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "ext-soap": "*",
         "ext-xml": "*",
         "upmind/provision-provider-base": "^3.7",
-        "metaregistrar/php-epp-client": "1.0.13",
+        "metaregistrar/php-epp-client": "1.0.14",
         "myclabs/php-enum": "^1.8",
         "propaganistas/laravel-phone": "^4.2",
         "guzzlehttp/guzzle": "^6.3|^7.0",

--- a/src/CentralNicReseller/Helper/EppHelper.php
+++ b/src/CentralNicReseller/Helper/EppHelper.php
@@ -692,9 +692,9 @@ class EppHelper
     }
 
     /**
-     * Get the domain renewal date from the EPP response.
+     * Get the domain expiration date from the EPP response.
      *
-     * CentralNic Reseller uses the keysys:renDate as the authoritative date for
+     * CentralNic Reseller uses the keysys:punDate as the authoritative date for
      * automated renewal or deletion. This date must always be present and is the
      * only date that should be used for expiration tracking.
      *
@@ -702,17 +702,17 @@ class EppHelper
      */
     private function getDomainExpirationDateFromResponse(eppResponse $response): string
     {
-        $renewalDate = $response->queryPath(
-            '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:renDate'
+        $paidUntilDate = $response->queryPath(
+            '/epp:epp/epp:response/epp:extension/keysys:resData/keysys:infData/keysys:punDate'
         );
 
-        if ($renewalDate === null) {
+        if ($paidUntilDate === null) {
             throw new ProvisionFunctionError(
-                'Renewal date (keysys:renDate) not found in EPP response'
+                'Paid Until date (keysys:punDate) not found in EPP response'
             );
         }
 
-        return $renewalDate;
+        return $paidUntilDate;
     }
 
     /**

--- a/src/CentralNicReseller/Provider.php
+++ b/src/CentralNicReseller/Provider.php
@@ -266,13 +266,6 @@ class Provider extends DomainNames implements ProviderInterface
     {
         $domainInfo = $this->epp()->getDomainInfo($domain);
 
-        /* Get the date that the domain is paid until, after this date the grace period will start  */
-        $paidUntil = $this->api()->statusDomain($domain)['PROPERTY']['PAIDUNTILDATE'][0] ?? null;
-        
-        if ($paidUntil) {
-            $domainInfo['expires_at'] = Utils::formatDate($paidUntil);
-        }
-
         return DomainResult::create($domainInfo, false)->setMessage($msg);
     }
 

--- a/src/CentralNicReseller/Provider.php
+++ b/src/CentralNicReseller/Provider.php
@@ -266,6 +266,13 @@ class Provider extends DomainNames implements ProviderInterface
     {
         $domainInfo = $this->epp()->getDomainInfo($domain);
 
+        /* Get the date that the domain is paid until, after this date the grace period will start  */
+        $paidUntil = $this->api()->statusDomain($domain)['PROPERTY']['PAIDUNTILDATE'][0] ?? null;
+        
+        if ($paidUntil) {
+            $domainInfo['expires_at'] = Utils::formatDate($paidUntil);
+        }
+
         return DomainResult::create($domainInfo, false)->setMessage($msg);
     }
 
@@ -564,8 +571,8 @@ class Provider extends DomainNames implements ProviderInterface
             $response = $this->api()->statusDomain($domainName);
 
             $statuses = $response['PROPERTY']['STATUS'] ?? [];
-            $expiresAt = isset($response['PROPERTY']['REGISTRATIONEXPIRATIONDATE'][0])
-                ? Carbon::parse($response['PROPERTY']['REGISTRATIONEXPIRATIONDATE'][0])
+            $expiresAt = isset($response['PROPERTY']['PAIDUNTILDATE'][0])
+                ? Carbon::parse($response['PROPERTY']['PAIDUNTILDATE'][0])
                 : null;
 
             // Check status codes for non-active states

--- a/src/Nominet/Provider.php
+++ b/src/Nominet/Provider.php
@@ -827,7 +827,7 @@ class Provider extends DomainNames implements ProviderInterface
                 $ips = $nameserver->getIpAddresses();
                 $returnNs['ns' . ($i + 1)] = [
                     "host" => trim($nameserver->getHostname(), '.'),
-                    "ip" => isset($ips) ? array_shift($ips) : null,
+                    "ip" => is_array($ips) ? array_shift($ips) : null,
                 ];
             }
         }

--- a/src/Nominet/Provider.php
+++ b/src/Nominet/Provider.php
@@ -824,6 +824,7 @@ class Provider extends DomainNames implements ProviderInterface
         if (isset($nameservers)) {
             /** @var eppHost $nameserver */
             foreach ($nameservers as $i => $nameserver) {
+                /** @var array<string>|null $ips */
                 $ips = $nameserver->getIpAddresses();
                 $returnNs['ns' . ($i + 1)] = [
                     "host" => trim($nameserver->getHostname(), '.'),


### PR DESCRIPTION
v2.12 pull request from #246 

- Fixed CentralNicReseller expiry date to use Paid Until date instead of registry date which included a grace period