### PR TITLE
DomainNameApi provider REST API implementation

### DIFF
--- a/src/Data/LockParams.php
+++ b/src/Data/LockParams.php
@@ -24,4 +24,9 @@ class LockParams extends DataSet
             'lock' => ['required', 'boolean'],
         ]);
     }
+
+    public function shouldLock(): bool
+    {
+        return (bool) $this->lock;
+    }
 }

--- a/src/Data/RegisterDomainParams.php
+++ b/src/Data/RegisterDomainParams.php
@@ -38,4 +38,9 @@ class RegisterDomainParams extends DataSet
             'additional_fields' => ['nullable', 'array'],
         ]);
     }
+
+    public function shouldWhoisPrivacy(): bool
+    {
+        return (bool) $this->whois_privacy;
+    }
 }

--- a/src/DomainNameApi/Data/DomainNameApiConfiguration.php
+++ b/src/DomainNameApi/Data/DomainNameApiConfiguration.php
@@ -8,7 +8,7 @@ use Upmind\ProvisionBase\Provider\DataSet\DataSet;
 use Upmind\ProvisionBase\Provider\DataSet\Rules;
 
 /**
- * DomainNamemApi configuration
+ * DomainNameApi configuration
  *
  * @property-read string $username Username
  * @property-read string $password Password
@@ -23,5 +23,10 @@ class DomainNameApiConfiguration extends DataSet
             'password' => ['required', 'string'],
             'sandbox' => ['boolean'],
         ]);
+    }
+
+    public function isSandbox(): bool
+    {
+        return $this->sandbox !== null && $this->sandbox === true;
     }
 }

--- a/src/DomainNameApi/Data/DomainNameApiConfiguration.php
+++ b/src/DomainNameApi/Data/DomainNameApiConfiguration.php
@@ -27,6 +27,6 @@ class DomainNameApiConfiguration extends DataSet
 
     public function isSandbox(): bool
     {
-        return $this->sandbox !== null && $this->sandbox === true;
+        return (bool) $this->sandbox;
     }
 }

--- a/src/DomainNameApi/Helper/DomainNameApiInterface.php
+++ b/src/DomainNameApi/Helper/DomainNameApiInterface.php
@@ -21,6 +21,22 @@ use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
 
 interface DomainNameApiInterface
 {
+    public const DOMAIN_STATUS_MAP = [
+        0  => 'Active',
+        1  => 'WaitingForRegistration',
+        2  => 'WaitingForDocument',
+        3  => 'WaitingForIncomingTransfer',
+        4  => 'TransferredOut',
+        7  => 'PendingDelete',
+        8  => 'Deleted',
+        9  => 'ConfirmationEmailSend',
+        11 => 'WaitingForOutgoingTransfer',
+        12 => 'PendingHold',
+        15 => 'ModificationPending',
+        18 => 'InCase',
+        19 => 'PendingRestore',
+    ];
+
     /**
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */

--- a/src/DomainNameApi/Helper/DomainNameApiInterface.php
+++ b/src/DomainNameApi/Helper/DomainNameApiInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper;
+
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+
+interface DomainNameApiInterface
+{
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function checkAvailability(DacParams $params): DacResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function registerWithContactInfo(RegisterDomainParams $params): DomainResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function transfer(TransferParams $params): DomainResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function renew(RenewParams $params): DomainResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getDetails(DomainInfoParams $params): DomainResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function modifyNameServer(UpdateNameserversParams $params): NameserversResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getEppCode(EppParams $params): EppCodeResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function saveContacts(UpdateContactParams $params): ContactResult;
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function toggleTheftProtectionLock(LockParams $params): DomainResult;
+}

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -844,9 +844,11 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             $errorMessages = 'unknown error';
         }
 
-        $errorMessage = !empty($errorMessages)
-            ? sprintf($errorMessagePlaceholder, $response->getStatusCode(), implode('. ', $errorMessages))
-            : sprintf($errorMessagePlaceholder, $response->getStatusCode(), 'unknown error');
+        $errorMessage = sprintf(
+            $errorMessagePlaceholder,
+            $response->getStatusCode(),
+            implode('. ', $errorMessages)
+        );
 
         throw ProvisionFunctionError::create($errorMessage, $requestEx)
             ->withDebug([

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -757,23 +757,24 @@ class DomainNameApiRestApi implements DomainNameApiInterface
 
             $statusCode = $response !== null ? $response->getStatusCode() : 0;
 
-            // Cases where status code is set, the response exists in the exception.
+            // Known status code cases, where the response exists in the exception.
             switch ($statusCode) {
-                case 400: $this->handleValidationError($response, $ex);
-                case 403: $this->handleError($response, $ex);
-                case 409: $this->handleError($response, $ex);
-                case 500: $this->handleError($response, $ex);
+                case 400:
+                case 403:
+                case 409:
+                case 500:
+                    $this->handleError($response, $ex);
+                default:
+                    throw ProvisionFunctionError::create(
+                        sprintf(
+                            'DomainNameAPI Provider Rest API Error [%d]: %s',
+                            $statusCode,
+                            'unknown error'
+                        ),
+                        $ex
+                    );
             }
 
-            // All other cases continue
-            throw ProvisionFunctionError::create(
-                sprintf(
-                    'DomainNameAPI Provider Rest API Error [%d]: %s',
-                    $statusCode,
-                    $ex->getMessage()
-                ),
-                $ex
-            );
         } catch (Throwable $ex) {
             if ($ex instanceof ProvisionFunctionError) {
                 throw $ex;
@@ -805,23 +806,31 @@ class DomainNameApiRestApi implements DomainNameApiInterface
     /**
      * @return no-return
      */
-    private function handleValidationError(ResponseInterface $response, RequestException $requestEx): void
+    private function handleError(ResponseInterface $response, RequestException $requestEx): void
     {
         // Reset pointer to start of stream and get content.
         $result = $response->getBody()->__toString();
 
         $response->getBody()->close();
 
+        $errorMessagePlaceholder = 'DomainNameAPI Rest Provider API Error [%d]: %s';
+
         try {
             $error = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            throw ProvisionFunctionError::create('DomainNameAPI Rest API Validation Error', $requestEx)
+            $errorMessage = sprintf ($errorMessagePlaceholder, $response->getStatusCode(), 'Invalid JSON Response');
+
+            throw ProvisionFunctionError::create($errorMessage, $requestEx)
                 ->withDebug([
-                    'result' => $result,
+                    'error_result' => $result
                 ]);
         }
 
         $errorMessages = [];
+
+        if (isset($error['message'])) {
+            $errorMessages[] = $error['message'];
+        }
 
         if (isset($error['error']['validationErrors'])) {
             foreach ($error['error']['validationErrors'] as $validationError) {
@@ -831,46 +840,17 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             }
         }
 
-        $errorMessagePlaceholder = 'DomainNameAPI Provider Rest API Error [%d]: %s';
-
-        $errorMessage = !empty($errorMessages)
-            ? sprintf($errorMessagePlaceholder, $response->getStatusCode(), implode(', ', $errorMessages))
-            : sprintf($errorMessagePlaceholder, $response->getStatusCode(), 'N/A');
-
-        throw ProvisionFunctionError::create($errorMessage, $requestEx)
-            ->withDebug([
-                'result' => $error,
-            ]);
-    }
-
-    /**
-     * @return no-return
-     */
-    private function handleError(ResponseInterface $response, RequestException $requestEx): void
-    {
-        // Reset pointer to start of stream and get content.
-        $result = $response->getBody()->__toString();
-
-        $response->getBody()->close();
-
-        try {
-            $error = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            throw ProvisionFunctionError::create('DomainNameAPI Rest API Error', $requestEx)
-                ->withDebug([
-                    'error' => $response,
-                ]);
+        if (empty($errorMessages)) {
+            $errorMessages = 'unknown error';
         }
 
-        $errorMessagePlaceholder = 'DomainNameAPI Provider Rest API Error [%d]: %s';
-
-        $errorMessage = isset($error['error']['message'])
-            ? sprintf($errorMessagePlaceholder, $response->getStatusCode(), $error['error']['message'])
-            : sprintf($errorMessagePlaceholder, $response->getStatusCode(), 'N/A');
+        $errorMessage = !empty($errorMessages)
+            ? sprintf($errorMessagePlaceholder, $response->getStatusCode(), implode('. ', $errorMessages))
+            : sprintf($errorMessagePlaceholder, $response->getStatusCode(), 'unknown error');
 
         throw ProvisionFunctionError::create($errorMessage, $requestEx)
             ->withDebug([
-                'result' => $error,
+                'error_result' => $result,
             ]);
     }
 }

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -48,7 +48,7 @@ class DomainNameApiRestApi implements DomainNameApiInterface
 
         // Get domain list
         $domains = array_map(
-            fn ($tld) => Utils::getDomain($params->sld, $tld),
+            static fn ($tld) => Utils::getDomain($params->sld, $tld),
             $params->tlds
         );
 
@@ -89,7 +89,10 @@ class DomainNameApiRestApi implements DomainNameApiInterface
                 'can_register' => $isAvailable,
                 'can_transfer' => !$isAvailable,
                 'is_premium' => isset($domain['isPremium']) && (bool) $domain['isPremium'] === true,
-                'description' => $domain['reason'] ?? '', // ToDo: Replace message with availability?
+                'description' => $result['reason'] ?? sprintf(
+                    'Domain is %s to register',
+                    $isAvailable ? 'available' : 'not available'
+                    ),
             ]);
         }
 

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -164,26 +164,35 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             ContactType::REGISTRANT()
         );
 
-        if ($params->admin->register !== null) {
-            $contacts[] = $this->mapContactParamsToProviderContact(
+        $contacts[] = $params->admin->register !== null
+            ? $this->mapContactParamsToProviderContact(
                 $params->admin->register,
                 ContactType::ADMIN()
+            )
+            : $this->mapContactParamsToProviderContact(
+                $params->registrant->register,
+                ContactType::ADMIN()
             );
-        }
 
-        if ($params->billing->register !== null) {
-            $contacts[] = $this->mapContactParamsToProviderContact(
+        $contacts[] = $params->billing->register !== null
+            ? $contacts[] = $this->mapContactParamsToProviderContact(
                 $params->billing->register,
                 ContactType::BILLING()
+            )
+            : $this->mapContactParamsToProviderContact(
+                $params->registrant->register,
+                ContactType::BILLING()
             );
-        }
 
-        if ($params->tech->register !== null) {
-            $contacts[] = $this->mapContactParamsToProviderContact(
+        $contacts[] = $params->tech->register !== null
+            ? $this->mapContactParamsToProviderContact(
                 $params->tech->register,
                 ContactType::TECH()
+            )
+            : $this->mapContactParamsToProviderContact(
+                $params->registrant->register,
+                ContactType::TECH()
             );
-        }
 
         $bodyParams['contacts'] = $contacts;
 

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -397,6 +397,13 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         // Get the current registrant details to use as fallback
         $currentRegistrantDetails = $domainInfo->registrant;
 
+        if ($currentRegistrantDetails === null) {
+            throw ProvisionFunctionError::create(sprintf(
+                'Please contact the registrant. Could not find registrant for domain: %s',
+                $domain
+            ));
+        }
+
         // Build the contacts array for each contact type, depending on the contact we want to update
         // Fetch the existing contacts for the contact type we don't want to update, but force sync if missing.
         // Contact list is always set as registrant, admin, tech, billing

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -548,6 +548,7 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             switch ($statusCode) {
                 case 400: $this->handleValidationError($response, $ex);
                 case 403: $this->handleError($response, $ex);
+                case 409: $this->handleError($response, $ex);
                 case 500: $this->handleError($response, $ex);
             }
 

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -119,6 +119,7 @@ class DomainNameApiRestApi implements DomainNameApiInterface
 
     /**
      * @throws \libphonenumber\NumberParseException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     public function registerWithContactInfo(RegisterDomainParams $params): DomainResult
     {
@@ -272,6 +273,9 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         throw ProvisionFunctionError::create('Domain transfer initiated');
     }
 
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function renew(RenewParams $params): DomainResult
     {
         $domain = Utils::getDomain($params->sld, $params->tld);
@@ -291,6 +295,9 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         ]))->setMessage('Domain renewed successfully');
     }
 
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function getDetails(DomainInfoParams $params): DomainResult
     {
         $domain = Utils::getDomain($params->sld, $params->tld);
@@ -312,6 +319,9 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         return $this->parseDomainInfo($domain, $result)->setMessage('Domain information retrieved');
     }
 
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function modifyNameServer(UpdateNameserversParams $params): NameserversResult
     {
         $domainName = Utils::getDomain($params->sld, $params->tld);
@@ -340,6 +350,9 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             ->setMessage('Nameservers are changed');
     }
 
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function getEppCode(EppParams $params): EppCodeResult
     {
         $domain = Utils::getDomain($params->sld, $params->tld);
@@ -359,14 +372,186 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         ]);
     }
 
+    /**
+     * @throws \libphonenumber\NumberParseException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function saveContacts(UpdateContactParams $params): ContactResult
     {
-        // TODO: Implement saveContacts() method.
+        try {
+            $contactType = $params->getContactTypeEnum();
+        } catch (UnexpectedValueException $ex) {
+            throw ProvisionFunctionError::create(sprintf(
+                'Invalid contact type:  %s',
+                $params->contact_type
+            ));
+        }
+
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        $domainInfo = $this->getDetails(DomainInfoParams::create([
+            'sld' => $params->sld,
+            'tld' => $params->tld,
+        ]));
+
+        // Get the current registrant details to use as fallback
+        $currentRegistrantDetails = $domainInfo->registrant;
+
+        // Build the contacts array for each contact type, depending on the contact we want to update
+        // Fetch the existing contacts for the contact type we don't want to update, but force sync if missing.
+        // Contact list is always set as registrant, admin, tech, billing
+        switch ($contactType) {
+            case $contactType->equals(ContactType::REGISTRANT()):
+                $contacts = [
+                    $this->mapContactParamsToProviderContact($params->contact, ContactType::REGISTRANT()),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->admin)
+                            ? ContactParams::create($domainInfo->admin->all())
+                            : ContactParams::create($params->contact),
+                        ContactType::ADMIN()
+                    ),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->tech)
+                            ? ContactParams::create($domainInfo->tech->all())
+                            : ContactParams::create($params->contact),
+                        ContactType::TECH()
+                    ),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->billing)
+                            ? ContactParams::create($domainInfo->billing->all())
+                            : ContactParams::create($params->contact),
+                        ContactType::BILLING()
+                    )
+                ];
+                break;
+            case $contactType->equals(ContactType::ADMIN()):
+                $contacts = [
+                    $this->mapContactParamsToProviderContact(
+                        ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::REGISTRANT()
+                    ),
+                    $this->mapContactParamsToProviderContact($params->contact, ContactType::ADMIN()),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->tech)
+                            ? ContactParams::create($domainInfo->tech->all())
+                            : ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::TECH()
+                    ),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->billing)
+                            ? ContactParams::create($domainInfo->billing->all())
+                            : ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::BILLING()
+                    )
+                ];
+                break;
+            case $contactType->equals(ContactType::TECH()):
+                $contacts = [
+                    $this->mapContactParamsToProviderContact(
+                        ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::REGISTRANT()
+                    ),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->admin)
+                            ? ContactParams::create($domainInfo->admin->all())
+                            : ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::ADMIN()
+                    ),
+                    $this->mapContactParamsToProviderContact($params->contact, ContactType::TECH()),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->billing)
+                            ? ContactParams::create($domainInfo->billing->all())
+                            : ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::BILLING()
+                    ),
+                ];
+                break;
+            case $contactType->equals(ContactType::BILLING()):
+                $contacts = [
+                    $this->mapContactParamsToProviderContact(
+                        ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::REGISTRANT()
+                    ),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->admin)
+                            ? ContactParams::create($domainInfo->admin->all())
+                            : ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::ADMIN()
+                    ),
+                    $this->mapContactParamsToProviderContact(
+                        isset($domainInfo->tech)
+                            ? ContactParams::create($domainInfo->tech->all())
+                            : ContactParams::create($currentRegistrantDetails->all()),
+                        ContactType::TECH()
+                    ),
+                    $this->mapContactParamsToProviderContact($params->contact, ContactType::BILLING()),
+                ];
+                break;
+            default:
+                throw ProvisionFunctionError::create(sprintf('Invalid contact type: %s', $params->contact_type));
+        }
+
+        // Returns 204 No Content response.
+        $this->makeRequest('domains/contacts/update', null, [
+            'domainName' => $domain,
+            'contacts' => $contacts,
+        ], 'PUT');
+
+        $updatedDomainInfo = $this->getDetails(DomainInfoParams::create([
+            'sld' => $params->sld,
+            'tld' => $params->tld,
+        ]));
+
+        switch ($contactType) {
+            case $contactType->equals(ContactType::REGISTRANT()):
+                $updatedContact = $updatedDomainInfo->registrant;
+                break;
+            case $contactType->equals(ContactType::ADMIN()):
+                $updatedContact = $updatedDomainInfo->admin;
+                break;
+            case $contactType->equals(ContactType::TECH()):
+                $updatedContact = $updatedDomainInfo->tech;
+                break;
+            case $contactType->equals(ContactType::BILLING()):
+                $updatedContact = $updatedDomainInfo->billing;
+                break;
+            default:
+                throw ProvisionFunctionError::create(sprintf('Invalid contact type: %s', $params->contact_type));
+        }
+
+        return ContactResult::create($updatedContact->all())
+            ->setMessage(sprintf('%s contact updated successfully', ucfirst($params->contact_type)));
     }
 
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function toggleTheftProtectionLock(LockParams $params): DomainResult
     {
-        // TODO: Implement toggleTheftProtectionLock() method.
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $domainInfo = $this->getDetails(DomainInfoParams::create([
+            'sld' => $params->sld,
+            'tld' => $params->tld,
+        ]));
+
+        if ($params->shouldLock() === $domainInfo->locked) {
+            return $domainInfo
+                ->setMessage(sprintf('Domain already %s', $params->shouldLock() ? 'locked' : 'unlocked'));
+        }
+
+        $bodyParams = [
+            'domainName' => $domainName,
+            'lockStatus' => $params->shouldLock()
+        ];
+
+        // Returns 204 No Content response.
+        $this->makeRequest('domains/lock', null, $bodyParams, 'POST');
+
+        $domainInfo->setLocked($params->shouldLock());
+
+        return $domainInfo
+            ->setMessage(sprintf('Domain successfully %s', $params->shouldLock() ? 'locked' : 'unlocked'));
     }
 
     private function parseDomainInfo(string $domainName, array $data): DomainResult

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Str;
 use JsonException;
+use Throwable;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
 use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
 use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
 use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
@@ -21,25 +25,77 @@ use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
 use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
 use Upmind\ProvisionProviders\DomainNames\Data\UpdateContactParams;
 use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
-use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Data\DomainNameApiConfiguration;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
 
 class DomainNameApiRestApi implements DomainNameApiInterface
 {
     public const PRODUCTION_URL = 'https://api.domainresellerapi.com/api/v1';
     public const OTE_URL = 'https://ote.domainresellerapi.com/api/v1';
 
-    protected Client $client;
-    protected DomainNameApiConfiguration $configuration;
+    private Client $client;
 
-    public function __construct(Client $client, DomainNameApiConfiguration $configuration)
+    public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->configuration = $configuration;
     }
 
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function checkAvailability(DacParams $params): DacResult
     {
-        // ToDo: Implement checkAvailability() method.
+        $bodyParams = [];
+
+        // Get domain list
+        $domains = array_map(
+            fn ($tld) => Utils::getDomain($params->sld, $tld),
+            $params->tlds
+        );
+
+        // Add domains to request body params
+        foreach ($domains as $domain) {
+            $bodyParams[] = ['domainName' => $domain];
+        }
+
+        $result = $this->makeRequest('domains/bulk-search', null, $bodyParams, 'POST');
+
+        if (!isset($result['success']) || (bool) $result['success'] === false) {
+            throw ProvisionFunctionError::create('Provider API Error - Domain Availability check failed')
+                ->withData([
+                    'response' => $result
+                ]);
+        }
+
+        $dacDomains = [];
+
+        // If not an array returned in the expected parsed response, return empty result.
+        if (empty($result['infos']) || !is_array($result['infos'])) {
+            return DacResult::create([
+                'domains' => $dacDomains
+            ]);
+        }
+
+        foreach ($result['infos'] as $domain) {
+            if (!is_array($domain)) {
+                continue;
+            }
+
+            $status = strtolower($item['status'] ?? '');
+            $isAvailable = in_array($status, ['available', '1', 'true']);
+
+            $dacDomains[] = DacDomain::create([
+                'domain' => $domain['domainName'],
+                'tld' => $domain['tld'],
+                'can_register' => $isAvailable,
+                'can_transfer' => !$isAvailable,
+                'is_premium' => isset($domain['isPremium']) && (bool) $domain['isPremium'] === true,
+                'description' => $domain['reason'] ?? '', // ToDo: Replace message with availability?
+            ]);
+        }
+
+        return DacResult::create([
+            'domains' => $dacDomains
+        ]);
     }
 
     public function registerWithContactInfo(RegisterDomainParams $params): DomainResult
@@ -83,26 +139,56 @@ class DomainNameApiRestApi implements DomainNameApiInterface
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
     private function makeRequest(
         string $endpoint,
-        ?array $params = null,
+        ?array $query = null,
         ?array $body = null,
         ?string $method = 'GET'
-    ): ?array {
-        $requestParams = [];
+    ): array {
+        $params = [];
 
-        if ($params !== null) {
-            $requestParams['query'] = $params;
+        if ($query !== null) {
+            $params['query'] = $query;
         }
 
         if ($body !== null) {
-            $requestParams['body'] = json_encode($body, JSON_THROW_ON_ERROR);
+            try {
+                $params['body'] = json_encode($body, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                throw ProvisionFunctionError::create('Invalid JSON Request Body')
+                    ->withData([
+                        'params' => $params,
+                    ]);
+            }
         }
 
-        $response = $this->client->request($method, $endpoint, $requestParams);
+        // Update endpoint to include leading `/` if it doesn't.
+        $endpoint = Str::startsWith($endpoint, '/') ? $endpoint : sprintf('/%s', $endpoint);
+
+        // Make API Call & handle errors.
+        try {
+            $response = $this->client->request($method, $endpoint, $params);
+        } catch (RequestException $ex) {
+            $response = $ex->getResponse();
+            $statusCode = $response !== null ? $response->getStatusCode() : 0;
+
+            throw ProvisionFunctionError::create(
+                sprintf(
+                    'DomainNameAPI Provider Rest API Error [%d]: %s',
+                    $statusCode,
+                    $ex->getMessage()
+                ),
+                $ex
+            );
+        } catch (Throwable $ex) {
+            if ($ex instanceof ProvisionFunctionError) {
+                throw $ex;
+            }
+
+            throw ProvisionFunctionError::create('DomainNameAPI Rest API error: ' . $ex->getMessage(), $ex);
+        }
 
         // Reset pointer to start of stream and get content.
         $result = $response->getBody()->__toString();
@@ -110,45 +196,16 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         $response->getBody()->close();
 
         if ($result === '') {
-            return null;
+            return [];
         }
 
-        return $this->parseResponseData($result);
-    }
-
-    /**
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    private function parseResponseData(string $result): array
-    {
         try {
-            $parsedResult = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+            return json_decode($result, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw ProvisionFunctionError::create('Invalid JSON Response')
                 ->withData([
                     'response' => $result,
                 ]);
         }
-
-        if (!$parsedResult) {
-            throw ProvisionFunctionError::create('Unknown Provider API Error')
-                ->withData([
-                    'response' => $result,
-                ]);
-        }
-
-        if ($error = $this->getResponseErrorMessage($parsedResult)) {
-            throw ProvisionFunctionError::create($error)
-                ->withData([
-                    'response' => $parsedResult,
-                ]);
-        }
-
-        return $parsedResult;
-    }
-
-    private function getBaseUrl(): string
-    {
-        return $this->configuration->isSandbox() ? self::OTE_URL : self::PRODUCTION_URL;
     }
 }

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -584,7 +584,28 @@ class DomainNameApiRestApi implements DomainNameApiInterface
                     $contact['ContactType'] ?? ($contact['contactType'] ?? '')
                 ));
             } catch (UnexpectedValueException $e) {
-                continue;
+                if (!isset($contact['handle'])) {
+                    continue;
+                }
+
+                // Use fallback by checking the contact handle first 3 characters
+                switch (mb_strtolower(mb_substr($contact['handle'], 0, 3))) {
+                    case 'd-r':
+                        $contactType = ContactType::REGISTRANT();
+                        break;
+                    case 'd-a':
+                        $contactType = ContactType::ADMIN();
+                        break;
+                    case 'd-b':
+                        $contactType = ContactType::BILLING();
+                        break;
+                    case 'd-t':
+                        $contactType = ContactType::TECH();
+                        break;
+                    default:
+                        // If no matching prefix found, continue the loop
+                        continue 2;
+                }
             }
 
             $domainInfo[$contactType->getValue()] = $this->mapProviderContactToContactData($contact);
@@ -655,7 +676,7 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         try {
             $phoneNumber = isset($contact['phoneCountryCode'], $contact['phone'])
                 ? Utils::eppPhoneToInternational(sprintf(
-                    '%s.%s',
+                    '+%s.%s',
                     $contact['phoneCountryCode'],
                     $contact['phone']
                 ))

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -6,16 +6,23 @@ namespace Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use JsonException;
+use Psr\Http\Message\ResponseInterface;
 use Throwable;
+use UnexpectedValueException;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
 use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
 use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
 use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
 use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
 use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
 use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\Enums\ContactType;
 use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
 use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
 use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
@@ -25,12 +32,21 @@ use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
 use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
 use Upmind\ProvisionProviders\DomainNames\Data\UpdateContactParams;
 use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Provider;
 use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
 
 class DomainNameApiRestApi implements DomainNameApiInterface
 {
-    public const PRODUCTION_URL = 'https://api.domainresellerapi.com/api/v1';
-    public const OTE_URL = 'https://ote.domainresellerapi.com/api/v1';
+    public const PRODUCTION_URL = 'https://api.domainresellerapi.com';
+    public const OTE_URL = 'https://ote.domainresellerapi.com';
+
+    /**
+     * Rest API Contact Types
+     */
+    public const CONTACT_TYPE_REGISTRANT = 'Registrant';
+    public const CONTACT_TYPE_ADMIN = 'Admin';
+    public const CONTACT_TYPE_TECH = 'Tech';
+    public const CONTACT_TYPE_BILLING = 'Billing';
 
     private Client $client;
 
@@ -80,12 +96,12 @@ class DomainNameApiRestApi implements DomainNameApiInterface
                 continue;
             }
 
-            $status = strtolower($item['status'] ?? '');
-            $isAvailable = in_array($status, ['available', '1', 'true']);
+            $status = strtolower(isset($domain['status']) ? (string) $domain['status'] : '');
+            $isAvailable = in_array($status, ['available', '1', 'true'], true);
 
             $dacDomains[] = DacDomain::create([
                 'domain' => $domain['domainName'],
-                'tld' => $domain['tld'],
+                'tld' => mb_strtolower($domain['tld']),
                 'can_register' => $isAvailable,
                 'can_transfer' => !$isAvailable,
                 'is_premium' => isset($domain['isPremium']) && (bool) $domain['isPremium'] === true,
@@ -101,34 +117,246 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         ]);
     }
 
+    /**
+     * @throws \libphonenumber\NumberParseException
+     */
     public function registerWithContactInfo(RegisterDomainParams $params): DomainResult
     {
-        // TODO: Implement registerWithContactInfo() method.
+        if ($params->registrant->register === null) {
+            throw ProvisionFunctionError::create('Registrant contact data is required for domain registration');
+        }
+
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        // Prepare POST payload
+        $bodyParams = [
+            'domainName' => $domainName,
+            'period' => $params->renew_years,
+            'privacyEnabled' => $params->shouldWhoisPrivacy(),
+        ];
+
+        // Add additional attributes if any to payload.
+        if (!empty($params->additional_fields)) {
+            $bodyParams['tldAttributes'] = $params->additional_fields;
+        }
+
+        // Add nameservers to payload
+        $nameServers = [];
+        for ($i = 1; $i <= Provider::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'nameservers.ns' . $i)) {
+                $nameServers[] = Arr::get($params, 'nameservers.ns' . $i)['host'];
+            }
+        }
+
+        if (empty($nameServers)) {
+            foreach (Provider::NAMESERVERS as $defaultNameserver) {
+                $nameServers[] = $defaultNameserver['host'];
+            }
+        }
+
+        $bodyParams['nameServers'] = $nameServers;
+
+        // Add contacts to payload
+        $contacts = [];
+        $contacts[] = $this->mapContactParamsToProviderContact(
+            $params->registrant->register,
+            ContactType::REGISTRANT()
+        );
+
+        if ($params->admin->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->admin->register,
+                ContactType::ADMIN()
+            );
+        }
+
+        if ($params->billing->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->billing->register,
+                ContactType::BILLING()
+            );
+        }
+
+        if ($params->tech->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->tech->register,
+                ContactType::TECH()
+            );
+        }
+
+        $bodyParams['contacts'] = $contacts;
+
+        $result = $this->makeRequest('domains/register-with-contacts', null, $bodyParams, 'POST');
+
+        if (empty($result)) {
+            throw ProvisionFunctionError::create(sprintf(
+                'Provider API Error - Domain Registration failed for %s',
+                $domainName
+            ));
+        }
+
+        return $this->getDetails(DomainInfoParams::create([
+            'sld' => $params->sld,
+            'tld' => $params->tld,
+        ]))->setMessage('Domain registered successfully');
     }
 
+    /**
+     * @throws \libphonenumber\NumberParseException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
     public function transfer(TransferParams $params): DomainResult
     {
-        // TODO: Implement transfer() method.
+        if ($params->epp_code === null) {
+            throw ProvisionFunctionError::create('EPP code is required for domain transfer');
+        }
+
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            return $this->getDetails(DomainInfoParams::create([
+                'sld' => $params->sld,
+                'tld' => $params->tld,
+            ]))->setMessage('Domain active in registrar account');
+        } catch (ProvisionFunctionError $e) {
+            // initiate transfer ...
+        }
+
+        $bodyParams = [
+            'domainName' => $domainName,
+            'authCode' => $params->epp_code,
+            'period' => $params->renew_years ?? 1,
+        ];
+
+        // Add contacts to payload
+        $contacts = [];
+
+        if ($params->registrant !== null && $params->registrant->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->registrant->register,
+                ContactType::REGISTRANT()
+            );
+        }
+
+        if ($params->admin !== null && $params->admin->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->admin->register,
+                ContactType::ADMIN()
+            );
+        }
+
+        if ($params->billing !== null && $params->billing->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->billing->register,
+                ContactType::BILLING()
+            );
+        }
+
+        if ($params->tech !== null && $params->tech->register !== null) {
+            $contacts[] = $this->mapContactParamsToProviderContact(
+                $params->tech->register,
+                ContactType::TECH()
+            );
+        }
+
+        if (!empty($contacts)) {
+            $bodyParams['contacts'] = $contacts;
+        }
+
+        $result = $this->makeRequest('domains/transfer', null, $bodyParams, 'POST');
+
+        if (empty($result)) {
+            throw ProvisionFunctionError::create(sprintf('Could not transfer domain %s', $domainName));
+        }
+
+        throw ProvisionFunctionError::create('Domain transfer initiated');
     }
 
     public function renew(RenewParams $params): DomainResult
     {
-        // TODO: Implement renew() method.
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        $result = $this->makeRequest('domains/renew', null, [
+            'domainName' => $domain,
+            'period' => $params->renew_years,
+        ], 'POST');
+
+        if (empty($result) || !isset($result['success']) || (bool) $result['success'] !== true) {
+            throw ProvisionFunctionError::create(sprintf('Could not renew domain %s', $domain));
+        }
+
+        return $this->getDetails(DomainInfoParams::create([
+            'sld' => $params->sld,
+            'tld' => $params->tld,
+        ]))->setMessage('Domain renewed successfully');
     }
 
     public function getDetails(DomainInfoParams $params): DomainResult
     {
-        // TODO: Implement getDetails() method.
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $result = $this->makeRequest('domains/info', ['DomainName' => $domain]);
+
+            if (empty($result)) {
+                throw ProvisionFunctionError::create('Domain not found');
+            }
+        } catch (ProvisionFunctionError $e) {
+            if ($e->getCode() === 404) {
+                throw ProvisionFunctionError::create('Domain not found');
+            }
+
+            throw $e;
+        }
+
+        return $this->parseDomainInfo($domain, $result)->setMessage('Domain information retrieved');
     }
 
     public function modifyNameServer(UpdateNameserversParams $params): NameserversResult
     {
-        // TODO: Implement modifyNameServer() method.
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $nameservers = [];
+
+        for ($i = 1; $i <= Provider::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'ns' . $i)) {
+                $nameservers[] = Arr::get($params, 'ns' . $i)['host'];
+            }
+        }
+
+        // Returns empty result
+        $this->makeRequest('domains/dns/name-server', null, [
+            'domainName' => $domainName,
+            'nameServers' => $nameservers,
+        ], 'PUT');
+
+        // Set nameservers
+        $nameServersCollection = Collection::make($nameservers);
+        $returnNameservers = $nameServersCollection
+            ->mapWithKeys(fn ($ns, $i) => ['ns' . ($i + 1) => $ns])
+            ->toArray();
+
+        return NameserversResult::create($returnNameservers)
+            ->setMessage('Nameservers are changed');
     }
 
     public function getEppCode(EppParams $params): EppCodeResult
     {
-        // TODO: Implement getEppCode() method.
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        $domainResult = $this->getDetails(DomainInfoParams::create([
+            'sld' => $params->sld,
+            'tld' => $params->tld,
+        ]));
+
+        // epp_code attribute is set via a magic setter when getting domain info.
+        if (!isset($domainResult->auth_code)) {
+            throw ProvisionFunctionError::create(sprintf('Could not retrieve Auth Code for %s', $domain));
+        }
+
+        return EppCodeResult::create([
+            'epp_code' => $domainResult->auth_code,
+        ]);
     }
 
     public function saveContacts(UpdateContactParams $params): ContactResult
@@ -139,6 +367,151 @@ class DomainNameApiRestApi implements DomainNameApiInterface
     public function toggleTheftProtectionLock(LockParams $params): DomainResult
     {
         // TODO: Implement toggleTheftProtectionLock() method.
+    }
+
+    private function parseDomainInfo(string $domainName, array $data): DomainResult
+    {
+        $domainInfo = [
+            'id' => (string) ($data['id'] ?? ($data['objectId'] ?? 0)),
+            'domain' => (string) ($data['domainName'] ?? ($data['name'] ?? $domainName)),
+            'statuses' => [$this->mapProviderDomainStatus((string) ($data['status'] ?? ''))],
+            'locked' => !empty($data['lockStatus']),
+            'whois_privacy' => !empty($data['privacyProtectionStatus']),
+            'auto_renew' => isset($data['renewalMode']) && mb_strtolower($data['renewalMode']) === 'autorenew',
+            'glue_records' => null,
+            'created_at' => isset($data['startDate']) ? Utils::formatDate($data['startDate']): null,
+            'updated_at' => isset($data['updatedDate']) ? Utils::formatDate($data['updatedDate']) : null,
+            'expires_at' => isset($data['expirationDate']) ? Utils::formatDate($data['expirationDate']): null,
+            'operation_status' => DomainResult::OPERATION_COMPLETE,
+        ];
+
+        // Set contacts
+        foreach ($data['contacts'] ?? [] as $contact) {
+            try {
+                $contactType = ContactType::from(mb_strtolower(
+                    $contact['ContactType'] ?? ($contact['contactType'] ?? '')
+                ));
+            } catch (UnexpectedValueException $e) {
+                continue;
+            }
+
+            $domainInfo[$contactType->getValue()] = $this->mapProviderContactToContactData($contact);
+        }
+
+        // Set nameservers
+        $nameServersCollection = Collection::make($data['nameServers'] ?? ($data['nameservers'] ?? []));
+        $nameservers = $nameServersCollection->mapWithKeys(fn ($host, $i) => ['ns' . ($i + 1) => ['host' => $host]]);
+
+        $domainInfo['ns'] = $nameservers->all();
+
+        // Set auth_code as well via magic method setter
+        $domainInfo['auth_code'] = $data['authCode'] ?? null;
+
+        return DomainResult::create($domainInfo);
+    }
+
+    /**
+     * @throws \libphonenumber\NumberParseException
+     */
+    private function mapContactParamsToProviderContact(ContactParams $params, ContactType $contactType): array
+    {
+        $name = $params->name ?: $params->organisation;
+        @[$firstName, $lastName] = explode(' ', $name, 2);
+
+        $firstName = trim($firstName);
+        $lastName = trim($lastName);
+
+        $eppPhone = Utils::internationalPhoneToEpp($params->phone);
+        $phoneDiallingCode = trim(Str::before($eppPhone, '.'), '+');
+        $phoneNumber = Str::after($eppPhone, '.');
+
+        return [
+            'contactType' => $this->getProviderContactTypeValue($contactType),
+            'firstName' => $firstName,
+            'lastName' => empty($lastName) ? $firstName : $lastName,
+            'companyName' => $params->organisation,
+            'eMail' => $params->email,
+            'address' => $params->address1,
+            'city' => $params->city,
+            'state' => $params->state ?? '',
+            'country' => Utils::normalizeCountryCode($params->country_code),
+            'postalCode' => $params->postcode,
+            'phoneCountryCode' => $phoneDiallingCode,
+            'phone' => $phoneNumber,
+        ];
+    }
+
+    private function mapProviderContactToContactData(array $contact): ?ContactData
+    {
+        // Set contact ID
+        $contactId = isset($contact['handle']) ? (string) $contact['handle'] : null;
+
+        if (!isset($contactId)) {
+            $contactId = isset($contact['id']) ? (string) $contact['id'] : null;
+        }
+
+        $contactName = implode(' ', array_filter([
+            isset($contact['firstName']) ? trim($contact['firstName']) : null,
+            isset($contact['lastName']) ? trim($contact['lastName']) : null,
+        ]));
+
+        if (empty($contactName)) {
+            $contactName = $contact['companyName'] ?? null;
+        }
+
+        // Don't fail for invalid phone number.
+        try {
+            $phoneNumber = isset($contact['phoneCountryCode'], $contact['phone'])
+                ? Utils::eppPhoneToInternational(sprintf(
+                    '%s.%s',
+                    $contact['phoneCountryCode'],
+                    $contact['phone']
+                ))
+                : null;
+        } catch (Throwable $e) {
+            $phoneNumber = null;
+        }
+
+        return ContactData::create([
+            'id' => $contactId,
+            'name' => $contactName,
+            'organisation' => $contact['companyName'] ?? null,
+            'email' => $contact['eMail'] ?? null,
+            'phone' => $phoneNumber,
+            'address1' => $contact['address'] ?? null,
+            'city' => $contact['city'] ?? null,
+            'state' => $contact['state'] ?? null,
+            'postcode' => $contact['postalCode'] ?? null,
+            'country_code' => isset($contact['country']) ? Utils::normalizeCountryCode($contact['country']) : null,
+        ]);
+    }
+
+    private function mapProviderDomainStatus(string $status): string
+    {
+        if (is_numeric($status) && array_key_exists((int)$status, self::DOMAIN_STATUS_MAP)) {
+            return self::DOMAIN_STATUS_MAP[(int) $status];
+        }
+
+        return $status;
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getProviderContactTypeValue(ContactType $contactType): string
+    {
+        switch ($contactType) {
+            case $contactType->equals(ContactType::REGISTRANT()):
+                return self::CONTACT_TYPE_REGISTRANT;
+            case $contactType->equals(ContactType::ADMIN()):
+                return self::CONTACT_TYPE_ADMIN;
+            case $contactType->equals(ContactType::BILLING()):
+                return self::CONTACT_TYPE_BILLING;
+            case $contactType->equals(ContactType::TECH()):
+                return self::CONTACT_TYPE_TECH;
+            default:
+                throw ProvisionFunctionError::create('Invalid contact type: ' . $contactType->getValue());
+        }
     }
 
     /**
@@ -157,26 +530,28 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         }
 
         if ($body !== null) {
-            try {
-                $params['body'] = json_encode($body, JSON_THROW_ON_ERROR);
-            } catch (JsonException $e) {
-                throw ProvisionFunctionError::create('Invalid JSON Request Body')
-                    ->withData([
-                        'params' => $params,
-                    ]);
-            }
+            $params['json'] = $body;
         }
 
-        // Update endpoint to include leading `/` if it doesn't.
-        $endpoint = Str::startsWith($endpoint, '/') ? $endpoint : sprintf('/%s', $endpoint);
+        // Set the path with the api/v1 prefix
+        $path = sprintf('/api/v1/%s', trim($endpoint, '/'));
 
         // Make API Call & handle errors.
         try {
-            $response = $this->client->request($method, $endpoint, $params);
+            $response = $this->client->request($method, $path, $params);
         } catch (RequestException $ex) {
             $response = $ex->getResponse();
+
             $statusCode = $response !== null ? $response->getStatusCode() : 0;
 
+            // Cases where status code is set, the response exists in the exception.
+            switch ($statusCode) {
+                case 400: $this->handleValidationError($response, $ex);
+                case 403: $this->handleError($response, $ex);
+                case 500: $this->handleError($response, $ex);
+            }
+
+            // All other cases continue
             throw ProvisionFunctionError::create(
                 sprintf(
                     'DomainNameAPI Provider Rest API Error [%d]: %s',
@@ -206,9 +581,82 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             return json_decode($result, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw ProvisionFunctionError::create('Invalid JSON Response')
-                ->withData([
-                    'response' => $result,
+                ->withDebug([
+                    'response' => $response,
+                    'result' => $result,
                 ]);
         }
+    }
+
+    /**
+     * @return no-return
+     */
+    private function handleValidationError(ResponseInterface $response, RequestException $requestEx): void
+    {
+        // Reset pointer to start of stream and get content.
+        $result = $response->getBody()->__toString();
+
+        $response->getBody()->close();
+
+        try {
+            $error = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ProvisionFunctionError::create('DomainNameAPI Rest API Validation Error', $requestEx)
+                ->withDebug([
+                    'result' => $result,
+                ]);
+        }
+
+        $errorMessages = [];
+
+        if (isset($error['error']['validationErrors'])) {
+            foreach ($error['error']['validationErrors'] as $validationError) {
+                if (isset($validationError['message'])) {
+                    $errorMessages[] = $validationError['message'];
+                }
+            }
+        }
+
+        $errorMessagePlaceholder = 'DomainNameAPI Provider Rest API Error [%d]: %s';
+
+        $errorMessage = !empty($errorMessages)
+            ? sprintf($errorMessagePlaceholder, $response->getStatusCode(), implode(', ', $errorMessages))
+            : sprintf($errorMessagePlaceholder, $response->getStatusCode(), 'N/A');
+
+        throw ProvisionFunctionError::create($errorMessage, $requestEx)
+            ->withDebug([
+                'result' => $error,
+            ]);
+    }
+
+    /**
+     * @return no-return
+     */
+    private function handleError(ResponseInterface $response, RequestException $requestEx): void
+    {
+        // Reset pointer to start of stream and get content.
+        $result = $response->getBody()->__toString();
+
+        $response->getBody()->close();
+
+        try {
+            $error = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ProvisionFunctionError::create('DomainNameAPI Rest API Error', $requestEx)
+                ->withDebug([
+                    'error' => $response,
+                ]);
+        }
+
+        $errorMessagePlaceholder = 'DomainNameAPI Provider Rest API Error [%d]: %s';
+
+        $errorMessage = isset($error['error']['message'])
+            ? sprintf($errorMessagePlaceholder, $response->getStatusCode(), $error['error']['message'])
+            : sprintf($errorMessagePlaceholder, $response->getStatusCode(), 'N/A');
+
+        throw ProvisionFunctionError::create($errorMessage, $requestEx)
+            ->withDebug([
+                'result' => $error,
+            ]);
     }
 }

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper;
+
+use GuzzleHttp\Client;
+use JsonException;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Data\DomainNameApiConfiguration;
+
+class DomainNameApiRestApi implements DomainNameApiInterface
+{
+    public const PRODUCTION_URL = 'https://api.domainresellerapi.com/api/v1';
+    public const OTE_URL = 'https://ote.domainresellerapi.com/api/v1';
+
+    protected Client $client;
+    protected DomainNameApiConfiguration $configuration;
+
+    public function __construct(Client $client, DomainNameApiConfiguration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    public function checkAvailability(DacParams $params): DacResult
+    {
+        // ToDo: Implement checkAvailability() method.
+    }
+
+    public function registerWithContactInfo(RegisterDomainParams $params): DomainResult
+    {
+        // TODO: Implement registerWithContactInfo() method.
+    }
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        // TODO: Implement transfer() method.
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        // TODO: Implement renew() method.
+    }
+
+    public function getDetails(DomainInfoParams $params): DomainResult
+    {
+        // TODO: Implement getDetails() method.
+    }
+
+    public function modifyNameServer(UpdateNameserversParams $params): NameserversResult
+    {
+        // TODO: Implement modifyNameServer() method.
+    }
+
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        // TODO: Implement getEppCode() method.
+    }
+
+    public function saveContacts(UpdateContactParams $params): ContactResult
+    {
+        // TODO: Implement saveContacts() method.
+    }
+
+    public function toggleTheftProtectionLock(LockParams $params): DomainResult
+    {
+        // TODO: Implement toggleTheftProtectionLock() method.
+    }
+
+    /**
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function makeRequest(
+        string $endpoint,
+        ?array $params = null,
+        ?array $body = null,
+        ?string $method = 'GET'
+    ): ?array {
+        $requestParams = [];
+
+        if ($params !== null) {
+            $requestParams['query'] = $params;
+        }
+
+        if ($body !== null) {
+            $requestParams['body'] = json_encode($body, JSON_THROW_ON_ERROR);
+        }
+
+        $response = $this->client->request($method, $endpoint, $requestParams);
+
+        // Reset pointer to start of stream and get content.
+        $result = $response->getBody()->__toString();
+
+        $response->getBody()->close();
+
+        if ($result === '') {
+            return null;
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function parseResponseData(string $result): array
+    {
+        try {
+            $parsedResult = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw ProvisionFunctionError::create('Invalid JSON Response')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    private function getBaseUrl(): string
+    {
+        return $this->configuration->isSandbox() ? self::OTE_URL : self::PRODUCTION_URL;
+    }
+}

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -633,7 +633,7 @@ class DomainNameApiRestApi implements DomainNameApiInterface
         ];
     }
 
-    private function mapProviderContactToContactData(array $contact): ?ContactData
+    private function mapProviderContactToContactData(array $contact): ContactData
     {
         // Set contact ID
         $contactId = isset($contact['handle']) ? (string) $contact['handle'] : null;

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -828,8 +828,8 @@ class DomainNameApiRestApi implements DomainNameApiInterface
 
         $errorMessages = [];
 
-        if (isset($error['message'])) {
-            $errorMessages[] = $error['message'];
+        if (isset($error['error']['message'])) {
+            $errorMessages[] = $error['error']['message'];
         }
 
         if (isset($error['error']['validationErrors'])) {

--- a/src/DomainNameApi/Helper/DomainNameApiRestApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiRestApi.php
@@ -164,35 +164,23 @@ class DomainNameApiRestApi implements DomainNameApiInterface
             ContactType::REGISTRANT()
         );
 
-        $contacts[] = $params->admin->register !== null
-            ? $this->mapContactParamsToProviderContact(
-                $params->admin->register,
-                ContactType::ADMIN()
-            )
-            : $this->mapContactParamsToProviderContact(
-                $params->registrant->register,
-                ContactType::ADMIN()
-            );
+        // Add Admin, fallback to registrant
+        $contacts[] = $this->mapContactParamsToProviderContact(
+            $params->admin->register ?? $params->registrant->register,
+            ContactType::ADMIN()
+        );
 
-        $contacts[] = $params->billing->register !== null
-            ? $contacts[] = $this->mapContactParamsToProviderContact(
-                $params->billing->register,
-                ContactType::BILLING()
-            )
-            : $this->mapContactParamsToProviderContact(
-                $params->registrant->register,
-                ContactType::BILLING()
-            );
+        // Add Billing, fallback to registrant
+        $contacts[] = $this->mapContactParamsToProviderContact(
+            $params->billing->register ?? $params->registrant->register,
+            ContactType::BILLING()
+        );
 
-        $contacts[] = $params->tech->register !== null
-            ? $this->mapContactParamsToProviderContact(
-                $params->tech->register,
-                ContactType::TECH()
-            )
-            : $this->mapContactParamsToProviderContact(
-                $params->registrant->register,
-                ContactType::TECH()
-            );
+        // Add Tech, fallback to registrant
+        $contacts[] = $this->mapContactParamsToProviderContact(
+            $params->tech->register ?? $params->registrant->register,
+            ContactType::TECH()
+        );
 
         $bodyParams['contacts'] = $contacts;
 

--- a/src/DomainNameApi/Helper/DomainNameApiSoapApi.php
+++ b/src/DomainNameApi/Helper/DomainNameApiSoapApi.php
@@ -1,0 +1,609 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Throwable;
+use UnexpectedValueException;
+use Upmind\DomainNameApiSdk\Client;
+use Upmind\DomainNameApiSdk\SDK\ArrayType\ArrayOfstring;
+use Upmind\DomainNameApiSdk\SDK\EnumType\ContactType;
+use Upmind\DomainNameApiSdk\SDK\StructType\BaseMethodResponse;
+use Upmind\DomainNameApiSdk\SDK\StructType\ContactInfo;
+use Upmind\DomainNameApiSdk\SDK\StructType\DisableTheftProtectionLock;
+use Upmind\DomainNameApiSdk\SDK\StructType\DisableTheftProtectionLockRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\DomainInfo;
+use Upmind\DomainNameApiSdk\SDK\StructType\EnableTheftProtectionLock;
+use Upmind\DomainNameApiSdk\SDK\StructType\EnableTheftProtectionLockRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\GetContacts;
+use Upmind\DomainNameApiSdk\SDK\StructType\GetContactsRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\GetDetails;
+use Upmind\DomainNameApiSdk\SDK\StructType\GetDetailsRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\ModifyNameServer;
+use Upmind\DomainNameApiSdk\SDK\StructType\ModifyNameServerRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\RegisterWithContactInfo;
+use Upmind\DomainNameApiSdk\SDK\StructType\RegisterWithContactInfoRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\Renew;
+use Upmind\DomainNameApiSdk\SDK\StructType\RenewRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\SaveContacts;
+use Upmind\DomainNameApiSdk\SDK\StructType\SaveContactsRequest;
+use Upmind\DomainNameApiSdk\SDK\StructType\Transfer;
+use Upmind\DomainNameApiSdk\SDK\StructType\TransferRequest;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\Enums\ContactType as DomainContactType;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Provider;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+
+class DomainNameApiSoapApi implements DomainNameApiInterface
+{
+    private Client $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function checkAvailability(DacParams $params): DacResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function registerWithContactInfo(RegisterDomainParams $params): DomainResult
+    {
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        $ownNameServers = [];
+        for ($i = 1; $i <= Provider::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'nameservers.ns' . $i)) {
+                $ownNameServers[] = Arr::get($params, 'nameservers.ns' . $i)['host'];
+            }
+        }
+
+        $nameServers = $ownNameServers ?: Provider::NAMESERVERS;
+
+        $request = (new RegisterWithContactInfoRequest())
+            ->setDomainName($domain)
+            ->setPeriod(intval($params->renew_years))
+            ->setNameServerList(new ArrayOfstring($nameServers))
+            ->setLockStatus(true)
+            ->setPrivacyProtectionStatus(true)
+            ->setRegistrantContact($this->contactParamsToSoap($params->registrant->register))
+            ->setAdministrativeContact($this->contactParamsToSoap($params->admin->register))
+            ->setBillingContact($this->contactParamsToSoap($params->billing->register))
+            ->setTechnicalContact($this->contactParamsToSoap($params->tech->register));
+
+        $response = $this->client->RegisterWithContactInfo(new RegisterWithContactInfo($request));
+        $result = $response->getRegisterWithContactInfoResult();
+
+        if ($result === null) {
+            $this->errorResult('Domain registration failed');
+        }
+
+        $domainInfo = $result->getDomainInfo();
+
+        if (!$domainInfo) {
+            $this->handleApiErrorResult(
+                $result,
+                $result->getErrorCode() == 2302 ? 'Domain name already exists' : null
+            );
+        }
+
+        return $this->domainInfoToResult($domainInfo)
+            ->setMessage('Domain registered successfully');
+    }
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            return $this->getDomainResult($domainName, true)
+                ->setMessage('Domain active in registrar account');
+        } catch (ProvisionFunctionError $e) {
+            // initiate transfer ...
+        }
+
+        $request = (new TransferRequest())
+            ->setDomainName($domainName)
+            ->setAuthCode($params->epp_code ?: null);
+        $response = $this->client->Transfer(new Transfer($request));
+        $result = $response->getTransferResult();
+
+        if ($result === null) {
+            $this->errorResult('Domain transfer failed');
+        }
+
+        $this->assertResultSuccess($result);
+
+        $this->errorResult('Domain transfer initiated');
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        $renewRequest = (new RenewRequest())
+            ->setDomainName($domain)
+            ->setPeriod(intval($params->renew_years));
+        $response = $this->client->Renew(new Renew($renewRequest));
+        $result = $response->getRenewResult();
+
+        if ($result === null) {
+            $this->errorResult('Domain renewal failed');
+        }
+
+        $this->assertResultSuccess($result);
+
+        return $this->getDomainResult($domain)
+            ->setMessage('Domain renewed successfully');
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getDetails(DomainInfoParams $params): DomainResult
+    {
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        return $this->getDomainResult($domain);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function modifyNameServer(UpdateNameserversParams $params): NameserversResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $nameservers = [];
+        for ($i = 1; $i <= Provider::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'ns' . $i)) {
+                $nameservers[] = Arr::get($params, 'ns' . $i)['host'];
+            }
+        }
+
+        $request = (new ModifyNameServerRequest())
+            ->setDomainName($domainName)
+            ->setNameServerList(new ArrayOfstring($nameservers));
+        $response = $this->client->ModifyNameServer(new ModifyNameServer($request));
+        $result = $response->getModifyNameServerResult();
+
+        if ($result === null) {
+            $this->errorResult('Nameservers update failed');
+        }
+
+        $this->assertResultSuccess($result);
+
+        /** @var \Illuminate\Support\Collection $returnNameserversCollection */
+        $returnNameserversCollection = collect($nameservers);
+
+        $returnNameservers = $returnNameserversCollection
+            ->mapWithKeys(fn ($ns, $i) => ['ns' . ($i + 1) => $ns])
+            ->toArray();
+
+        return NameserversResult::create($returnNameservers)
+            ->setMessage('Nameservers are changed');
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        $domainInfo = $this->getDomainInfo(Utils::getDomain($params->sld, $params->tld));
+
+        return EppCodeResult::create(['epp_code' => $domainInfo->getAuth()]);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function saveContacts(UpdateContactParams $params): ContactResult
+    {
+        try {
+            $contactType = $params->getContactTypeEnum();
+
+            $isUpdatingRegistrant = $contactType->equals(DomainContactType::REGISTRANT());
+        } catch (UnexpectedValueException $ex) {
+            $this->errorResult('Invalid contact type: ' . $params->contact_type);
+        }
+
+        $domain = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $contactResults = $this->getContactResults($domain);
+        } catch (ProvisionFunctionError $e) {
+            if ($e->getMessage() !== Provider::ERR_REGISTRANT_NOT_SET) {
+                throw $e;
+            }
+
+            $contactResults = [];
+        }
+
+        // Get the current registrant details to use as fallback
+        $currentRegistrantDetails = $contactResults[DomainContactType::REGISTRANT()->getValue()];
+
+        /**
+         * Due to some instances of domains having no contacts whatsoever, and DomainNameApi requiring all to be passed,
+         * and if we are not updating a specific contact type,
+         * we will fall back to the registrant contact for all contact types if they are not present.
+         */
+        $request = (new SaveContactsRequest())->setDomainName($domain);
+
+        switch ($contactType) {
+            case $contactType->equals(DomainContactType::REGISTRANT()):
+                $contactSoapParams = $this->contactParamsToSoap($params->contact);
+
+                $request
+                    ->setRegistrantContact($contactSoapParams)
+                    ->setAdministrativeContact(isset($contactResults['admin'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['admin'], false))
+                        : $contactSoapParams
+                    )->setTechnicalContact(isset($contactResults['tech'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['tech'], false))
+                        : $contactSoapParams
+                    )->setBillingContact(isset($contactResults['billing'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['billing'], false))
+                        : $contactSoapParams
+                    );
+                break;
+            case $contactType->equals(DomainContactType::ADMIN()):
+                $registrantSoapParams = $this->contactParamsToSoap($currentRegistrantDetails);
+
+                $request
+                    ->setRegistrantContact($registrantSoapParams)
+                    ->setAdministrativeContact($this->contactParamsToSoap($params->contact))
+                    ->setTechnicalContact(isset($contactResults['tech'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['tech'], false))
+                        : $registrantSoapParams
+                    )->setBillingContact(isset($contactResults['billing'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['billing'], false))
+                        : $registrantSoapParams
+                    );
+                break;
+            case $contactType->equals(DomainContactType::TECH()):
+                $registrantSoapParams = $this->contactParamsToSoap($currentRegistrantDetails);
+
+                $request
+                    ->setRegistrantContact($registrantSoapParams)
+                    ->setAdministrativeContact(isset($contactResults['admin'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['admin'], false))
+                        : $registrantSoapParams
+                    )->setTechnicalContact($this->contactParamsToSoap($params->contact))
+                    ->setBillingContact(isset($contactResults['billing'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['billing'], false))
+                        : $registrantSoapParams
+                    );
+                break;
+            case $contactType->equals(DomainContactType::BILLING()):
+                $registrantSoapParams = $this->contactParamsToSoap($currentRegistrantDetails);
+
+                $request
+                    ->setRegistrantContact($registrantSoapParams)
+                    ->setAdministrativeContact(isset($contactResults['admin'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['admin'], false))
+                        : $registrantSoapParams
+                    )->setTechnicalContact(isset($contactResults['tech'])
+                        ? $this->contactParamsToSoap(new ContactParams($contactResults['tech'], false))
+                        : $registrantSoapParams
+                    )
+                    ->setBillingContact($this->contactParamsToSoap($params->contact));
+                break;
+        }
+
+        $response = $this->client->SaveContacts(new SaveContacts($request));
+        $result = $response->getSaveContactsResult();
+
+        if ($result === null) {
+            $this->errorResult(ucfirst($contactType->getValue()) . ' contact update failed');
+        }
+
+        $this->assertResultSuccess($result);
+
+        return $this->getContactResults($domain)[$contactType->getValue()]->setMessage(
+            ucfirst($contactType->getValue()) . ' contact updated'
+        );
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function toggleTheftProtectionLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $domainResult = $this->getDomainResult($domainName);
+
+        if ($domainResult->locked == $params->lock) {
+            return $domainResult
+                ->setMessage(sprintf('Domain already %s', $params->lock ? 'locked' : 'unlocked'));
+        }
+
+        if ($params->lock) {
+            $request = (new EnableTheftProtectionLockRequest())
+                ->setDomainName($domainName);
+            $response = $this->client->EnableTheftProtectionLock(new EnableTheftProtectionLock($request));
+            $result = $response->getEnableTheftProtectionLockResult();
+        } else {
+            $request = (new DisableTheftProtectionLockRequest())
+                ->setDomainName($domainName);
+            $response = $this->client->DisableTheftProtectionLock(new DisableTheftProtectionLock($request));
+            $result = $response->getDisableTheftProtectionLockResult();
+        }
+
+        if ($result === null) {
+            $this->errorResult('Domain lock operation failed');
+        }
+
+        $this->assertResultSuccess($result);
+
+        return $domainResult
+            ->setMessage(sprintf('Domain successfully %s', $params->lock ? 'locked' : 'unlocked'))
+            ->setLocked(!!$params->lock);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getDomainResult(string $domain, bool $assertActive = false): DomainResult
+    {
+        return $this->domainInfoToResult($this->getDomainInfo($domain, $assertActive))
+            ->setMessage('Domain info retrieved');
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getDomainInfo(string $domain, bool $assertActive = false): DomainInfo
+    {
+        $getDetailsRequest = (new GetDetailsRequest())
+            ->setDomainName($domain);
+        $response = $this->client->GetDetails(new GetDetails($getDetailsRequest));
+        $result = $response->getGetDetailsResult();
+
+        if ($result === null) {
+            $this->errorResult('Domain not found');
+        }
+
+        if (!$domainInfo = $result->getDomainInfo()) {
+            $this->handleApiErrorResult($result);
+        }
+
+        if ($assertActive && $domainInfo->getStatus() !== 'Active') {
+            $this->errorResult(sprintf('Domain is %s', $domainInfo->getStatus()), [
+                'domain' => $domain,
+                'statuses' => [
+                    $domainInfo->getStatus(),
+                    $domainInfo->getStatusCode(),
+                ]
+            ]);
+        }
+
+        return $domainInfo;
+    }
+
+    /**
+     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
+     */
+    private function contactParamsToSoap(ContactParams $params): ContactInfo
+    {
+        @[$firstName, $lastName] = explode(' ', $params->name ?: $params->organisation, 2);
+
+        $eppPhone = Utils::internationalPhoneToEpp($params->phone);
+        $phoneDiallingCode = trim(Str::before($eppPhone, '.'), '+');
+        $phoneNumber = Str::after($eppPhone, '.');
+
+        $contactInfo = new ContactInfo();
+
+        $contactInfo->setType(ContactType::VALUE_CONTACT);
+        $contactInfo->setFirstName($firstName);
+        $contactInfo->setLastName(empty($lastName) ? $firstName : $lastName);
+        $contactInfo->setCompany($params->organisation);
+        $contactInfo->setAddressLine1(trim((string)$params->address1) ?: 'N/A');
+        $contactInfo->setCity(trim((string)$params->city) ?: 'N/A');
+        $contactInfo->setState(strtoupper($params->country_code ?? '') === 'US' ? $params->state : null);
+        $contactInfo->setZipCode(trim((string)$params->postcode) ?: 'N/A');
+        $contactInfo->setCountry($params->country_code);
+        $contactInfo->setEMail($params->email);
+        $contactInfo->setPhoneCountryCode($phoneDiallingCode);
+        $contactInfo->setPhone($phoneNumber);
+        $contactInfo->setStatus('');
+
+        return $contactInfo;
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function domainInfoToResult(DomainInfo $domainInfo): DomainResult
+    {
+        $contacts = $this->getContactResults($domainInfo->getDomainName(), false);
+
+        $nameServersList = $domainInfo->getNameServerList();
+
+        // Empty array if nameServersList is null.
+        /** @var \Illuminate\Support\Collection $nameServersCollection */
+        $nameServersCollection = collect($nameServersList !== null ? $nameServersList->getString() : []);
+        $nameservers = $nameServersCollection
+            ->mapWithKeys(fn ($host, $i) => ['ns' . ($i + 1) => ['host' => $host]]);
+
+        /** @var \Illuminate\Support\Collection $statusesCollection */
+        $statusesCollection = collect([$domainInfo->getStatus() ?? 'Unknown', $domainInfo->getStatusCode()]);
+        $statuses = $statusesCollection
+            ->filter()
+            ->map(fn($status) => ucfirst(strtolower((string)$status)))
+            ->unique()
+            ->values()
+            ->toArray();
+
+        return DomainResult::create([
+            'id' => (string)$domainInfo->getId(),
+            'domain' => $domainInfo->getDomainName(),
+            'statuses' => $statuses,
+            'locked' => $domainInfo->getLockStatus(),
+            'registrant' => $contacts['registrant'] ?? null,
+            'billing' => $contacts['billing'] ?? null,
+            'tech' => $contacts['tech'] ?? null,
+            'admin' => $contacts['admin'] ?? null,
+            'ns' => $nameservers,
+            'created_at' => $this->formatDate($domainInfo->getTransferDate() ?? $domainInfo->getStartDate()),
+            'updated_at' => $this->formatDate($domainInfo->getUpdatedDate()),
+            'expires_at' => $this->formatDate($domainInfo->getExpirationDate()),
+        ]);
+    }
+
+    /**
+     * @return ContactResult[]|array<string,ContactResult>
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getContactResults(string $domainName, bool $throwIfMissing = true): array
+    {
+        $request = (new GetContactsRequest())
+            ->setDomainName($domainName);
+        $response = $this->client->GetContacts(new GetContacts($request));
+        $result = $response->getGetContactsResult();
+
+        if ($result === null) {
+            if ($throwIfMissing) {
+                $this->errorResult('Domain Contact details not found');
+            }
+
+            return [];
+        }
+
+        if (!$result->getRegistrantContact()) {
+            if ($throwIfMissing) {
+                $this->handleApiErrorResult($result, Provider::ERR_REGISTRANT_NOT_SET);
+            }
+
+            return [];
+        }
+
+        return [
+            'registrant' => $this->contactInfoToResult($result->getRegistrantContact()),
+            'billing' => $this->contactInfoToResult($result->getBillingContact()),
+            'tech' => $this->contactInfoToResult($result->getTechnicalContact()),
+            'admin' => $this->contactInfoToResult($result->getAdministrativeContact()),
+        ];
+    }
+
+    private function contactInfoToResult(?ContactInfo $contactInfo): ?ContactResult
+    {
+        if (empty($contactInfo)) {
+            return null;
+        }
+
+        if ($contactInfo->getPhone()) {
+            $phone = '+' . $contactInfo->getPhoneCountryCode() . $contactInfo->getPhone();
+        }
+
+        $country = $contactInfo->getCountry();
+        if (!preg_match('/^[A-Z]{2}$/', strtoupper($country))) {
+            $country = Utils::countryToCode($country);
+        }
+
+        return ContactResult::create($this->emptyContactValuesToNull([
+            'id' => (string)$contactInfo->getId(),
+            'name' => trim($contactInfo->getFirstName() . ' ' . $contactInfo->getLastName()),
+            'organisation' => $contactInfo->getCompany(),
+            'email' => $contactInfo->getEmail(),
+            'phone' => $phone ?? null,
+            'address1' => $contactInfo->getAddressLine1(),
+            'city' => $contactInfo->getCity(),
+            'state' => $contactInfo->getState(),
+            'postcode' => $contactInfo->getZipCode(),
+            'country_code' => Utils::normalizeCountryCode($country),
+        ]));
+    }
+
+    private function emptyContactValuesToNull($data): array
+    {
+        $empty = [
+            '',
+            'n/a',
+        ];
+
+        return array_map(fn ($value) => in_array($value, $empty, true) ? null : $value, $data);
+    }
+
+    private function formatDate(?string $date): ?string
+    {
+        if (!isset($date)) {
+            return $date;
+        }
+        return Carbon::parse($date)->toDateTimeString();
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function assertResultSuccess(BaseMethodResponse $result, ?string $errorMessage = null): void
+    {
+        if ($result->getOperationResult() !== 'SUCCESS') {
+            $this->handleApiErrorResult($result, $errorMessage);
+        }
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function handleApiErrorResult(BaseMethodResponse $result, ?string $errorMessage = null): void
+    {
+        $errorMessage = $errorMessage ?: sprintf('Provider error: %s', $this->getApiErrorResultMessage($result));
+
+        $this->errorResult($errorMessage, [
+            'error_code' => $result->getErrorCode(),
+            'operation_result' => $result->getOperationResult(),
+            'operation_message' => $result->getOperationMessage(),
+        ]);
+    }
+
+    private function getApiErrorResultMessage(BaseMethodResponse $result): string
+    {
+        $message = $result->getOperationMessage() ?? 'Unknown error';
+
+        return str_replace('Invalid api request for filed', 'Invalid api request for field', $message);
+    }
+
+    /**
+     * Throw an error to fail this provision function execution.
+     *
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function errorResult($message, array $data = [], array $debug = [], ?Throwable $previous = null): void
+    {
+        throw (new ProvisionFunctionError($message, 0, $previous))
+            ->withData($data)
+            ->withDebug($debug);
+    }
+}

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -291,7 +291,7 @@ class Provider extends DomainNames implements ProviderInterface
             'http_errors' => true, // Ensure Guzzle always throws exceptions on HTTP errors.
         ]);
 
-        $this->restApiClient = new DomainNameApiRestApi($client, $this->configuration);
+        $this->restApiClient = new DomainNameApiRestApi($client);
 
         return $this->restApiClient;
     }

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -154,6 +154,7 @@ class Provider extends DomainNames implements ProviderInterface
 
     /**
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     * @throws \Throwable
      */
     public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
     {

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -96,6 +96,7 @@ class Provider extends DomainNames implements ProviderInterface
     }
 
     /**
+     * @throws \libphonenumber\NumberParseException
      * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
@@ -277,10 +278,11 @@ class Provider extends DomainNames implements ProviderInterface
                 : DomainNameApiRestApi::PRODUCTION_URL,
             'headers' => [
                 'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/DomainNameApi',
+                'Accept' => 'application/json',
                 'Content-Type' => 'application/json',
                 // Authorization is header based.
-                '__reseller: ' . $this->configuration->username,
-                'X-API-KEY: ' . $this->configuration->password,
+                '__reseller' => $this->configuration->username,
+                'X-API-KEY' => $this->configuration->password,
             ],
             'connect_timeout' => 10,
             'timeout' => 60,

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -276,12 +276,14 @@ class Provider extends DomainNames implements ProviderInterface
                 : DomainNameApiRestApi::PRODUCTION_URL,
             'headers' => [
                 'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/DomainNameApi',
-                'Authorization' => "sso-key {$this->configuration->api_key}:{$this->configuration->api_secret}",
                 'Content-Type' => 'application/json',
+                // Authorization is header based.
+                '__reseller: ' . $this->configuration->username,
+                'X-API-KEY: ' . $this->configuration->password,
             ],
             'connect_timeout' => 10,
             'timeout' => 60,
-            'verify' => !$this->configuration->isSandbox(),
+            'verify' => !$this->configuration->isSandbox(), // SSL verify only for production.
             'handler' => $this->getGuzzleHandlerStack(),
         ]);
 

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -249,7 +249,7 @@ class Provider extends DomainNames implements ProviderInterface
             $client = (new ClientFactory())->create(
                 $this->configuration->username,
                 $this->configuration->password,
-                $this->configuration->sandbox ? ClientFactory::ENV_TEST : ClientFactory::ENV_LIVE,
+                $this->configuration->isSandbox() ? ClientFactory::ENV_TEST : ClientFactory::ENV_LIVE,
                 $this->getLogger(),
                 [
                     'keep_alive' => false

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -4,42 +4,14 @@ declare(strict_types=1);
 
 namespace Upmind\ProvisionProviders\DomainNames\DomainNameApi;
 
-use Carbon\Carbon;
-use Illuminate\Support\Arr;
+use GuzzleHttp\Client;
 use Illuminate\Support\Str;
 use Throwable;
-use UnexpectedValueException;
-use Upmind\DomainNameApiSdk\Client as DomainNameApiSdkClient;
 use Upmind\DomainNameApiSdk\ClientFactory;
-use Upmind\DomainNameApiSdk\SDK\ArrayType\ArrayOfstring;
-use Upmind\DomainNameApiSdk\SDK\EnumType\ContactType;
-use Upmind\DomainNameApiSdk\SDK\StructType\BaseMethodResponse;
-use Upmind\DomainNameApiSdk\SDK\StructType\ContactInfo;
-use Upmind\DomainNameApiSdk\SDK\StructType\DisableTheftProtectionLock;
-use Upmind\DomainNameApiSdk\SDK\StructType\DisableTheftProtectionLockRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\DomainInfo;
-use Upmind\DomainNameApiSdk\SDK\StructType\EnableTheftProtectionLock;
-use Upmind\DomainNameApiSdk\SDK\StructType\EnableTheftProtectionLockRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\GetContacts;
-use Upmind\DomainNameApiSdk\SDK\StructType\GetContactsRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\GetDetails;
-use Upmind\DomainNameApiSdk\SDK\StructType\GetDetailsRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\ModifyNameServer;
-use Upmind\DomainNameApiSdk\SDK\StructType\ModifyNameServerRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\RegisterWithContactInfo;
-use Upmind\DomainNameApiSdk\SDK\StructType\RegisterWithContactInfoRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\Renew;
-use Upmind\DomainNameApiSdk\SDK\StructType\RenewRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\SaveContacts;
-use Upmind\DomainNameApiSdk\SDK\StructType\SaveContactsRequest;
-use Upmind\DomainNameApiSdk\SDK\StructType\Transfer;
-use Upmind\DomainNameApiSdk\SDK\StructType\TransferRequest;
-use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionBase\Provider\DataSet\ResultData;
 use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
-use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
 use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
 use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
 use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
@@ -62,8 +34,9 @@ use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
 use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
 use Upmind\ProvisionProviders\DomainNames\Data\StatusResult;
 use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Data\DomainNameApiConfiguration;
-use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
-
+use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper\DomainNameApiInterface;
+use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper\DomainNameApiRestApi;
+use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Helper\DomainNameApiSoapApi;
 use Upmind\ProvisionProviders\DomainNames\Data\VerificationStatusParams;
 use Upmind\ProvisionProviders\DomainNames\Data\VerificationStatusResult;
 use Upmind\ProvisionProviders\DomainNames\Data\ResendVerificationParams;
@@ -74,30 +47,24 @@ use Upmind\ProvisionProviders\DomainNames\Data\GlueRecordsResult;
 
 class Provider extends DomainNames implements ProviderInterface
 {
-    /**
-     * @var DomainNameApiConfiguration
-     */
-    protected $configuration;
-
-    /**
-     * @var DomainNameApiSdkClient|null
-     */
-    protected $apiClient;
+    protected DomainNameApiConfiguration $configuration;
+    protected ?DomainNameApiSoapApi $apiClient = null;
+    protected ?DomainNameApiRestApi $restApiClient = null;
 
     /**
      * Max positions for nameservers
      */
-    private const MAX_CUSTOM_NAMESERVERS = 4;
+    public const MAX_CUSTOM_NAMESERVERS = 4;
 
     /**
      * Common nameservers for DomainNameApi
      */
-    private const NAMESERVERS = [
+    public const NAMESERVERS = [
         ['host' => 'ns1.domainnameapi.com'],
         ['host' => 'ns2.domainnameapi.com']
     ];
 
-    private const ERR_REGISTRANT_NOT_SET = 'Registrant contact details not set';
+    public const ERR_REGISTRANT_NOT_SET = 'Registrant contact details not set';
 
     public function __construct(DomainNameApiConfiguration $configuration)
     {
@@ -117,7 +84,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function domainAvailabilityCheck(DacParams $params): DacResult
     {
-        $this->errorResult('Operation not supported');
+        return $this->api()->checkAvailability($params);
     }
 
     /**
@@ -134,46 +101,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function register(RegisterDomainParams $params): DomainResult
     {
-        $domain = Utils::getDomain($params->sld, $params->tld);
-
-        $ownNameServers = [];
-        for ($i = 1; $i <= self::MAX_CUSTOM_NAMESERVERS; $i++) {
-            if (Arr::has($params, 'nameservers.ns' . $i)) {
-                $ownNameServers[] = Arr::get($params, 'nameservers.ns' . $i)['host'];
-            }
-        }
-
-        $nameServers = $ownNameServers ?: self::NAMESERVERS;
-
-        $request = (new RegisterWithContactInfoRequest())
-            ->setDomainName($domain)
-            ->setPeriod(intval($params->renew_years))
-            ->setNameServerList(new ArrayOfstring($nameServers))
-            ->setLockStatus(true)
-            ->setPrivacyProtectionStatus(true)
-            ->setRegistrantContact($this->contactParamsToSoap($params->registrant->register))
-            ->setAdministrativeContact($this->contactParamsToSoap($params->admin->register))
-            ->setBillingContact($this->contactParamsToSoap($params->billing->register))
-            ->setTechnicalContact($this->contactParamsToSoap($params->tech->register));
-
-        $response = $this->api()->RegisterWithContactInfo(new RegisterWithContactInfo($request));
-        $result = $response->getRegisterWithContactInfoResult();
-
-        if ($result === null) {
-            $this->errorResult('Domain registration failed');
-        }
-
-        $domainInfo = $result->getDomainInfo();
-
-        if (!$domainInfo) {
-            $this->handleApiErrorResult(
-                $result,
-                $result->getErrorCode() == 2302 ? 'Domain name already exists' : null
-            );
-        }
-
-        return $this->domainInfoToResult($domainInfo)
-            ->setMessage('Domain registered successfully');
+        return $this->api()->registerWithContactInfo($params);
     }
 
     /**
@@ -181,28 +109,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function transfer(TransferParams $params): DomainResult
     {
-        $domainName = Utils::getDomain($params->sld, $params->tld);
-
-        try {
-            return $this->getDomainResult($domainName, true)
-                ->setMessage('Domain active in registrar account');
-        } catch (ProvisionFunctionError $e) {
-            // initiate transfer ...
-        }
-
-        $request = (new TransferRequest())
-            ->setDomainName($domainName)
-            ->setAuthCode($params->epp_code ?: null);
-        $response = $this->api()->Transfer(new Transfer($request));
-        $result = $response->getTransferResult();
-
-        if ($result === null) {
-            $this->errorResult('Domain transfer failed');
-        }
-
-        $this->assertResultSuccess($result);
-
-        $this->errorResult('Domain transfer initiated');
+        return $this->api()->transfer($params);
     }
 
     /**
@@ -210,22 +117,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function renew(RenewParams $params): DomainResult
     {
-        $domain = Utils::getDomain($params->sld, $params->tld);
-
-        $renewRequest = (new RenewRequest())
-            ->setDomainName($domain)
-            ->setPeriod(intval($params->renew_years));
-        $response = $this->api()->Renew(new Renew($renewRequest));
-        $result = $response->getRenewResult();
-
-        if ($result === null) {
-            $this->errorResult('Domain renewal failed');
-        }
-
-        $this->assertResultSuccess($result);
-
-        return $this->getDomainResult($domain)
-            ->setMessage('Domain renewed successfully');
+        return $this->api()->renew($params);
     }
 
     /**
@@ -233,9 +125,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function getInfo(DomainInfoParams $params): DomainResult
     {
-        $domain = Utils::getDomain($params->sld, $params->tld);
-
-        return $this->getDomainResult($domain);
+        return $this->api()->getDetails($params);
     }
 
     /**
@@ -243,36 +133,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function updateNameservers(UpdateNameserversParams $params): NameserversResult
     {
-        $domainName = Utils::getDomain($params->sld, $params->tld);
-
-        $nameservers = [];
-        for ($i = 1; $i <= self::MAX_CUSTOM_NAMESERVERS; $i++) {
-            if (Arr::has($params, 'ns' . $i)) {
-                $nameservers[] = Arr::get($params, 'ns' . $i)['host'];
-            }
-        }
-
-        $request = (new ModifyNameServerRequest())
-            ->setDomainName($domainName)
-            ->setNameServerList(new ArrayOfstring($nameservers));
-        $response = $this->api()->ModifyNameServer(new ModifyNameServer($request));
-        $result = $response->getModifyNameServerResult();
-
-        if ($result === null) {
-            $this->errorResult('Nameservers update failed');
-        }
-
-        $this->assertResultSuccess($result);
-
-        /** @var \Illuminate\Support\Collection $returnNameserversCollection */
-        $returnNameserversCollection = collect($nameservers);
-
-        $returnNameservers = $returnNameserversCollection
-            ->mapWithKeys(fn ($ns, $i) => ['ns' . ($i + 1) => $ns])
-            ->toArray();
-
-        return NameserversResult::create($returnNameservers)
-            ->setMessage('Nameservers are changed');
+        return $this->api()->modifyNameServer($params);
     }
 
     /**
@@ -280,9 +141,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function getEppCode(EppParams $params): EppCodeResult
     {
-        $domainInfo = $this->getDomainInfo(Utils::getDomain($params->sld, $params->tld));
-
-        return EppCodeResult::create(['epp_code' => $domainInfo->getAuth()]);
+        return $this->api()->getEppCode($params);
     }
 
     /**
@@ -312,109 +171,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function updateContact(UpdateContactParams $params): ContactResult
     {
-        try {
-            $contactType = $params->getContactTypeEnum();
-
-            $isUpdatingRegistrant = $contactType->equals(DomainContactType::REGISTRANT());
-        } catch (UnexpectedValueException $ex) {
-            $this->errorResult('Invalid contact type: ' . $params->contact_type);
-        }
-
-        $domain = Utils::getDomain($params->sld, $params->tld);
-
-        try {
-            $contactResults = $this->getContactResults($domain);
-        } catch (ProvisionFunctionError $e) {
-            if ($e->getMessage() !== self::ERR_REGISTRANT_NOT_SET) {
-                throw $e;
-            }
-
-            $contactResults = [];
-        }
-
-        // Get the current registrant details to use as fallback
-        $currentRegistrantDetails = $contactResults[DomainContactType::REGISTRANT()->getValue()];
-
-        /**
-         * Due to some instances of domains having no contacts whatsoever, and DomainNameApi requiring all to be passed,
-         * and if we are not updating a specific contact type,
-         * we will fall back to the registrant contact for all contact types if they are not present.
-         */
-        $request = (new SaveContactsRequest())->setDomainName($domain);
-
-        switch ($contactType) {
-            case $contactType->equals(DomainContactType::REGISTRANT()):
-                $contactSoapParams = $this->contactParamsToSoap($params->contact);
-
-                $request
-                    ->setRegistrantContact($contactSoapParams)
-                    ->setAdministrativeContact(isset($contactResults['admin'])
-                        ? $this->contactParamsToSoap(new ContactParams($contactResults['admin'], false))
-                        : $contactSoapParams
-                    )->setTechnicalContact(isset($contactResults['tech'])
-                        ? $this->contactParamsToSoap(new ContactParams($contactResults['tech'], false))
-                        : $contactSoapParams
-                    )->setBillingContact(isset($contactResults['billing'])
-                        ? $this->contactParamsToSoap(new ContactParams($contactResults['billing'], false))
-                        : $contactSoapParams
-                    );
-                    break;
-                case $contactType->equals(DomainContactType::ADMIN()):
-                    $registrantSoapParams = $this->contactParamsToSoap($currentRegistrantDetails);
-
-                    $request
-                        ->setRegistrantContact($registrantSoapParams)
-                        ->setAdministrativeContact($this->contactParamsToSoap($params->contact))
-                        ->setTechnicalContact(isset($contactResults['tech'])
-                            ? $this->contactParamsToSoap(new ContactParams($contactResults['tech'], false))
-                            : $registrantSoapParams
-                        )->setBillingContact(isset($contactResults['billing'])
-                            ? $this->contactParamsToSoap(new ContactParams($contactResults['billing'], false))
-                            : $registrantSoapParams
-                        );
-                    break;
-                case $contactType->equals(DomainContactType::TECH()):
-                    $registrantSoapParams = $this->contactParamsToSoap($currentRegistrantDetails);
-
-                    $request
-                        ->setRegistrantContact($registrantSoapParams)
-                        ->setAdministrativeContact(isset($contactResults['admin'])
-                            ? $this->contactParamsToSoap(new ContactParams($contactResults['admin'], false))
-                            : $registrantSoapParams
-                        )->setTechnicalContact($this->contactParamsToSoap($params->contact))
-                        ->setBillingContact(isset($contactResults['billing'])
-                            ? $this->contactParamsToSoap(new ContactParams($contactResults['billing'], false))
-                            : $registrantSoapParams
-                        );
-                    break;
-                case $contactType->equals(DomainContactType::BILLING()):
-                    $registrantSoapParams = $this->contactParamsToSoap($currentRegistrantDetails);
-
-                    $request
-                        ->setRegistrantContact($registrantSoapParams)
-                        ->setAdministrativeContact(isset($contactResults['admin'])
-                            ? $this->contactParamsToSoap(new ContactParams($contactResults['admin'], false))
-                            : $registrantSoapParams
-                        )->setTechnicalContact(isset($contactResults['tech'])
-                            ? $this->contactParamsToSoap(new ContactParams($contactResults['tech'], false))
-                            : $registrantSoapParams
-                        )
-                        ->setBillingContact($this->contactParamsToSoap($params->contact));
-                    break;
-        }
-
-        $response = $this->api()->SaveContacts(new SaveContacts($request));
-        $result = $response->getSaveContactsResult();
-
-        if ($result === null) {
-            $this->errorResult(ucfirst($contactType->getValue()) . ' contact update failed');
-        }
-
-        $this->assertResultSuccess($result);
-
-        return $this->getContactResults($domain)[$contactType->getValue()]->setMessage(
-            ucfirst($contactType->getValue()) . ' contact updated'
-        );
+        return $this->api()->saveContacts($params);
     }
 
     /**
@@ -422,35 +179,7 @@ class Provider extends DomainNames implements ProviderInterface
      */
     public function setLock(LockParams $params): DomainResult
     {
-        $domainName = Utils::getDomain($params->sld, $params->tld);
-        $domainResult = $this->getDomainResult($domainName);
-
-        if ($domainResult->locked == $params->lock) {
-            return $domainResult
-                ->setMessage(sprintf('Domain already %s', $params->lock ? 'locked' : 'unlocked'));
-        }
-
-        if ($params->lock) {
-            $request = (new EnableTheftProtectionLockRequest())
-                ->setDomainName($domainName);
-            $response = $this->api()->EnableTheftProtectionLock(new EnableTheftProtectionLock($request));
-            $result = $response->getEnableTheftProtectionLockResult();
-        } else {
-            $request = (new DisableTheftProtectionLockRequest())
-                ->setDomainName($domainName);
-            $response = $this->api()->DisableTheftProtectionLock(new DisableTheftProtectionLock($request));
-            $result = $response->getDisableTheftProtectionLockResult();
-        }
-
-        if ($result === null) {
-            $this->errorResult('Domain lock operation failed');
-        }
-
-        $this->assertResultSuccess($result);
-
-        return $domainResult
-            ->setMessage(sprintf('Domain successfully %s', $params->lock ? 'locked' : 'unlocked'))
-            ->setLocked(!!$params->lock);
+        return $this->api()->toggleTheftProtectionLock($params);
     }
 
     /**
@@ -461,251 +190,10 @@ class Provider extends DomainNames implements ProviderInterface
         $this->errorResult('Operation not supported');
     }
 
-    /**
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function getDomainResult(string $domain, bool $assertActive = false): DomainResult
+    protected function api(): DomainNameApiInterface
     {
-        return $this->domainInfoToResult($this->getDomainInfo($domain, $assertActive))
-            ->setMessage('Domain info retrieved');
-    }
-
-    /**
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function getDomainInfo(string $domain, bool $assertActive = false): DomainInfo
-    {
-        $getDetailsRequest = (new GetDetailsRequest())
-            ->setDomainName($domain);
-        $response = $this->api()->GetDetails(new GetDetails($getDetailsRequest));
-        $result = $response->getGetDetailsResult();
-
-        if ($result === null) {
-            $this->errorResult('Domain not found');
-        }
-
-        if (!$domainInfo = $result->getDomainInfo()) {
-            $this->handleApiErrorResult($result);
-        }
-
-        if ($assertActive && $domainInfo->getStatus() !== 'Active') {
-            $this->errorResult(sprintf('Domain is %s', $domainInfo->getStatus()), [
-                'domain' => $domain,
-                'statuses' => [
-                    $domainInfo->getStatus(),
-                    $domainInfo->getStatusCode(),
-                ]
-            ]);
-        }
-
-        return $domainInfo;
-    }
-
-    /**
-     * @return ContactResult[]|array<string,ContactResult>
-     *
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function getContactResults(string $domainName, bool $throwIfMissing = true): array
-    {
-        $request = (new GetContactsRequest())
-            ->setDomainName($domainName);
-        $response = $this->api()->GetContacts(new GetContacts($request));
-        $result = $response->getGetContactsResult();
-
-        if ($result === null) {
-            if ($throwIfMissing) {
-                $this->errorResult('Domain Contact details not found');
-            }
-
-            return [];
-        }
-
-        if (!$result->getRegistrantContact()) {
-            if ($throwIfMissing) {
-                $this->handleApiErrorResult($result, self::ERR_REGISTRANT_NOT_SET);
-            }
-
-            return [];
-        }
-
-        return [
-            'registrant' => $this->contactInfoToResult($result->getRegistrantContact()),
-            'billing' => $this->contactInfoToResult($result->getBillingContact()),
-            'tech' => $this->contactInfoToResult($result->getTechnicalContact()),
-            'admin' => $this->contactInfoToResult($result->getAdministrativeContact()),
-        ];
-    }
-
-    protected function contactInfoToResult(?ContactInfo $contactInfo): ?ContactResult
-    {
-        if (empty($contactInfo)) {
-            return null;
-        }
-
-        if ($contactInfo->getPhone()) {
-            $phone = '+' . $contactInfo->getPhoneCountryCode() . $contactInfo->getPhone();
-        }
-
-        $country = $contactInfo->getCountry();
-        if (!preg_match('/^[A-Z]{2}$/', strtoupper($country))) {
-            $country = Utils::countryToCode($country);
-        }
-
-        return ContactResult::create($this->emptyContactValuesToNull([
-            'id' => (string)$contactInfo->getId(),
-            'name' => trim($contactInfo->getFirstName() . ' ' . $contactInfo->getLastName()),
-            'organisation' => $contactInfo->getCompany(),
-            'email' => $contactInfo->getEmail(),
-            'phone' => $phone ?? null,
-            'address1' => $contactInfo->getAddressLine1(),
-            'city' => $contactInfo->getCity(),
-            'state' => $contactInfo->getState(),
-            'postcode' => $contactInfo->getZipCode(),
-            'country_code' => Utils::normalizeCountryCode($country),
-        ]));
-    }
-
-    protected function emptyContactValuesToNull($data): array
-    {
-        $empty = [
-            '',
-            'n/a',
-        ];
-
-        return array_map(fn ($value) => in_array($value, $empty, true) ? null : $value, $data);
-    }
-
-    /**
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function domainInfoToResult(DomainInfo $domainInfo): DomainResult
-    {
-        $contacts = $this->getContactResults($domainInfo->getDomainName(), false);
-
-        $nameServersList = $domainInfo->getNameServerList();
-
-        // Empty array if nameServersList is null.
-        /** @var \Illuminate\Support\Collection $nameServersCollection */
-        $nameServersCollection = collect($nameServersList !== null ? $nameServersList->getString() : []);
-        $nameservers = $nameServersCollection
-            ->mapWithKeys(fn ($host, $i) => ['ns' . ($i + 1) => ['host' => $host]]);
-
-        /** @var \Illuminate\Support\Collection $statusesCollection */
-        $statusesCollection = collect([$domainInfo->getStatus() ?? 'Unknown', $domainInfo->getStatusCode()]);
-        $statuses = $statusesCollection
-            ->filter()
-            ->map(fn($status) => ucfirst(strtolower((string)$status)))
-            ->unique()
-            ->values()
-            ->toArray();
-
-        return DomainResult::create([
-            'id' => (string)$domainInfo->getId(),
-            'domain' => $domainInfo->getDomainName(),
-            'statuses' => $statuses,
-            'locked' => $domainInfo->getLockStatus(),
-            'registrant' => $contacts['registrant'] ?? null,
-            'billing' => $contacts['billing'] ?? null,
-            'tech' => $contacts['tech'] ?? null,
-            'admin' => $contacts['admin'] ?? null,
-            'ns' => $nameservers,
-            'created_at' => $this->formatDate($domainInfo->getTransferDate() ?? $domainInfo->getStartDate()),
-            'updated_at' => $this->formatDate($domainInfo->getUpdatedDate()),
-            'expires_at' => $this->formatDate($domainInfo->getExpirationDate()),
-        ]);
-    }
-
-    protected function formatDate(?string $date): ?string
-    {
-        if (!isset($date)) {
-            return $date;
-        }
-        return Carbon::parse($date)->toDateTimeString();
-    }
-
-    /**
-     * @throws \Propaganistas\LaravelPhone\Exceptions\NumberParseException
-     */
-    protected function contactParamsToSoap(ContactParams $params): ContactInfo
-    {
-        @[$firstName, $lastName] = explode(' ', $params->name ?: $params->organisation, 2);
-
-        $eppPhone = Utils::internationalPhoneToEpp($params->phone);
-        $phoneDiallingCode = trim(Str::before($eppPhone, '.'), '+');
-        $phoneNumber = Str::after($eppPhone, '.');
-
-        $contactInfo = new ContactInfo();
-
-        $contactInfo->setType(ContactType::VALUE_CONTACT);
-        $contactInfo->setFirstName($firstName);
-        $contactInfo->setLastName(empty($lastName) ? $firstName : $lastName);
-        $contactInfo->setCompany($params->organisation);
-        $contactInfo->setAddressLine1(trim((string)$params->address1) ?: 'N/A');
-        $contactInfo->setCity(trim((string)$params->city) ?: 'N/A');
-        $contactInfo->setState(strtoupper($params->country_code ?? '') === 'US' ? $params->state : null);
-        $contactInfo->setZipCode(trim((string)$params->postcode) ?: 'N/A');
-        $contactInfo->setCountry($params->country_code);
-        $contactInfo->setEMail($params->email);
-        $contactInfo->setPhoneCountryCode($phoneDiallingCode);
-        $contactInfo->setPhone($phoneNumber);
-        $contactInfo->setStatus('');
-
-        return $contactInfo;
-    }
-
-    /**
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function assertResultSuccess(BaseMethodResponse $result, ?string $errorMessage = null): void
-    {
-        if ($result->getOperationResult() !== 'SUCCESS') {
-            $this->handleApiErrorResult($result, $errorMessage);
-        }
-    }
-
-    /**
-     * @return no-return
-     *
-     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
-     */
-    protected function handleApiErrorResult(BaseMethodResponse $result, ?string $errorMessage = null): void
-    {
-        $errorMessage = $errorMessage ?: sprintf('Provider error: %s', $this->getApiErrorResultMessage($result));
-
-        $this->errorResult($errorMessage, [
-            'error_code' => $result->getErrorCode(),
-            'operation_result' => $result->getOperationResult(),
-            'operation_message' => $result->getOperationMessage(),
-        ]);
-    }
-
-    protected function getApiErrorResultMessage(BaseMethodResponse $result): string
-    {
-        $message = $result->getOperationMessage() ?? 'Unknown error';
-
-        return str_replace('Invalid api request for filed', 'Invalid api request for field', $message);
-    }
-
-    protected function api(): DomainNameApiSdkClient
-    {
-        if (isset($this->apiClient)) {
-            return $this->apiClient;
-        }
-
-        try {
-            return $this->apiClient = (new ClientFactory())->create(
-                $this->configuration->username,
-                $this->configuration->password,
-                $this->configuration->sandbox ? ClientFactory::ENV_TEST : ClientFactory::ENV_LIVE,
-                $this->getLogger(),
-                [
-                    'keep_alive' => false
-                ]
-            );
-        } catch (Throwable $e) {
-            $this->errorResult('Failed to connect to API', ['exception' => $e->getMessage()], [], $e);
-        }
+        // If username is a UUID, that's the Reseller ID that points to the Rest API requirement.
+        return Str::isUuid($this->configuration->username) ? $this->getRestApi() : $this->getSoapApi();
     }
 
     /**
@@ -740,7 +228,6 @@ class Provider extends DomainNames implements ProviderInterface
         $this->errorResult('Operation not supported', $params);
     }
 
-
     /**
      * @inheritDoc
      */
@@ -750,5 +237,56 @@ class Provider extends DomainNames implements ProviderInterface
             ->setStatus(StatusResult::STATUS_NOT_IMPLEMENTED)
             ->setExpiresAt(null)
             ->setRawStatuses(null);
+    }
+
+    private function getSoapApi(): DomainNameApiSoapApi
+    {
+        if (isset($this->apiClient)) {
+            return $this->apiClient;
+        }
+
+        try {
+            $client = (new ClientFactory())->create(
+                $this->configuration->username,
+                $this->configuration->password,
+                $this->configuration->sandbox ? ClientFactory::ENV_TEST : ClientFactory::ENV_LIVE,
+                $this->getLogger(),
+                [
+                    'keep_alive' => false
+                ]
+            );
+
+            $this->apiClient = new DomainNameApiSoapApi($client);
+
+            return $this->apiClient;
+        } catch (Throwable $e) {
+            $this->errorResult('Failed to connect to API', ['exception' => $e->getMessage()], [], $e);
+        }
+    }
+
+    private function getRestApi(): DomainNameApiRestApi
+    {
+        if ($this->restApiClient !== null) {
+            return $this->restApiClient;
+        }
+
+        $client = new Client([
+            'base_uri' => $this->configuration->isSandbox()
+                ? DomainNameApiRestApi::OTE_URL
+                : DomainNameApiRestApi::PRODUCTION_URL,
+            'headers' => [
+                'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/DomainNameApi',
+                'Authorization' => "sso-key {$this->configuration->api_key}:{$this->configuration->api_secret}",
+                'Content-Type' => 'application/json',
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'verify' => !$this->configuration->isSandbox(),
+            'handler' => $this->getGuzzleHandlerStack(),
+        ]);
+
+        $this->restApiClient = new DomainNameApiRestApi($client, $this->configuration);
+
+        return $this->restApiClient;
     }
 }

--- a/src/DomainNameApi/Provider.php
+++ b/src/DomainNameApi/Provider.php
@@ -285,6 +285,7 @@ class Provider extends DomainNames implements ProviderInterface
             'timeout' => 60,
             'verify' => !$this->configuration->isSandbox(), // SSL verify only for production.
             'handler' => $this->getGuzzleHandlerStack(),
+            'http_errors' => true, // Ensure Guzzle always throws exceptions on HTTP errors.
         ]);
 
         $this->restApiClient = new DomainNameApiRestApi($client, $this->configuration);


### PR DESCRIPTION
- Add REST API implementation for `DomainNameAPI`
- Move SOAP implementation from Provider to separate class
- For backwards compatibility, use common underlying interface for each category function
- For backwards compatibility, automatically select between REST or SOAP implementation, on whether the "username" (Reseller ID) is a UUID (REST) or not (SOAP), as per the vendor's library https://github.com/domainreseller/php-dna